### PR TITLE
DR-643 Set datarepoGcsAllowreuseexistingbuckets=true for integration 1-5 and temp environments.

### DIFF
--- a/dev/mm/mmDeployment.yaml
+++ b/dev/mm/mmDeployment.yaml
@@ -20,7 +20,7 @@ gcloud-sqlproxy:
 datarepo-api:
   enabled: true
   image:
-    tag: bd0b2cf
+    tag: marikoInfoAppProp1
   env:
     googleProjectid:  broad-jade-mm
     dbDatarepoUsername:  drmanager
@@ -30,6 +30,7 @@ datarepo-api:
     dbDatarepoUri: jdbc:postgresql://mm-jade-gcloud-sqlproxy.mm:5432/datarepo-mm
     dbStairwayForceclean: true
     dbMigrateDropallonstart: true
+    datarepoGcsAllowreuseexistingbuckets: true
   serviceAccount:
     create: true
   rbac:

--- a/integration/integration-1/integration-1Deployment.yaml
+++ b/integration/integration-1/integration-1Deployment.yaml
@@ -29,6 +29,7 @@ datarepo-api:
     dbStairwayUri: jdbc:postgresql://integration-1-jade-gcloud-sqlproxy.integration-1:5432/stairway-1
     dbDatarepoUri: jdbc:postgresql://integration-1-jade-gcloud-sqlproxy.integration-1:5432/datarepo-1
     itJadeApiUrl: https://jade-1.datarepo-integration.broadinstitute.org
+    datarepoGcsAllowreuseexistingbuckets: true
   serviceAccount:
     create: true
   rbac:

--- a/integration/integration-2/integration-2Deployment.yaml
+++ b/integration/integration-2/integration-2Deployment.yaml
@@ -29,6 +29,7 @@ datarepo-api:
     dbStairwayUri: jdbc:postgresql://integration-2-jade-gcloud-sqlproxy.integration-2:5432/stairway-2
     dbDatarepoUri: jdbc:postgresql://integration-2-jade-gcloud-sqlproxy.integration-2:5432/datarepo-2
     itJadeApiUrl: https://jade-2.datarepo-integration.broadinstitute.org
+    datarepoGcsAllowreuseexistingbuckets: true
   serviceAccount:
     create: true
   rbac:

--- a/integration/integration-3/integration-3Deployment.yaml
+++ b/integration/integration-3/integration-3Deployment.yaml
@@ -29,6 +29,7 @@ datarepo-api:
     dbStairwayUri: jdbc:postgresql://integration-3-jade-gcloud-sqlproxy.integration-3:5432/stairway-3
     dbDatarepoUri: jdbc:postgresql://integration-3-jade-gcloud-sqlproxy.integration-3:5432/datarepo-3
     itJadeApiUrl: https://jade-3.datarepo-integration.broadinstitute.org
+    datarepoGcsAllowreuseexistingbuckets: true
   serviceAccount:
     create: true
   rbac:

--- a/integration/integration-4/integration-4Deployment.yaml
+++ b/integration/integration-4/integration-4Deployment.yaml
@@ -29,6 +29,7 @@ datarepo-api:
     dbStairwayUri: jdbc:postgresql://integration-4-jade-gcloud-sqlproxy.integration-4:5432/stairway-4
     dbDatarepoUri: jdbc:postgresql://integration-4-jade-gcloud-sqlproxy.integration-4:5432/datarepo-4
     itJadeApiUrl: https://jade-4.datarepo-integration.broadinstitute.org
+    datarepoGcsAllowreuseexistingbuckets: true
   serviceAccount:
     create: true
   rbac:

--- a/integration/integration-5/integration-5Deployment.yaml
+++ b/integration/integration-5/integration-5Deployment.yaml
@@ -29,6 +29,7 @@ datarepo-api:
     dbStairwayUri: jdbc:postgresql://integration-5-jade-gcloud-sqlproxy.integration-5:5432/stairway-5
     dbDatarepoUri: jdbc:postgresql://integration-5-jade-gcloud-sqlproxy.integration-5:5432/datarepo-5
     itJadeApiUrl: https://jade-5.datarepo-integration.broadinstitute.org
+    datarepoGcsAllowreuseexistingbuckets: true
   serviceAccount:
     create: true
   rbac:

--- a/integration/temp/tempDeployment.yaml
+++ b/integration/temp/tempDeployment.yaml
@@ -29,6 +29,7 @@ datarepo-api:
     dbStairwayUri: jdbc:postgresql://temp-jade-gcloud-sqlproxy.temp:5432/stairway
     dbDatarepoUri: jdbc:postgresql://temp-jade-gcloud-sqlproxy.temp:5432/datarepo
     itJadeApiUrl: https://jade-temp.datarepo-integration.broadinstitute.org
+    datarepoGcsAllowreuseexistingbuckets: true
   serviceAccount:
     create: true
   rbac:


### PR DESCRIPTION
Overrode the default and set datarepo.gcs.allowReuseExistingBuckets=true for the testing environments: integration-1, -2, -3, -4, -5, and temp.

I tested this on my dev namespace: deployed with the same chart modifications, used a custom image that wrote out the property value on startup.