### PR TITLE
Updating all dev environments to datarepo chart 0.1.5

### DIFF
--- a/dev/argocd/argocd.yaml
+++ b/dev/argocd/argocd.yaml
@@ -3,9 +3,13 @@ repoServer:
   serviceAccount:
     create: true
     name: argocd-repo-server
+  nodeSelector:
+    cloud.google.com/gke-nodepool: dev-node
 redis:
   enabled: flase
 redis-ha:
+  nodeSelector:
+    cloud.google.com/gke-nodepool: dev-node
   enabled: true
   serviceAccount:
     create: true
@@ -14,6 +18,8 @@ configs:
   secret:
     createSecret: false
 server:
+  nodeSelector:
+    cloud.google.com/gke-nodepool: dev-node
   extraArgs:
     - --insecure
   config:
@@ -58,3 +64,9 @@ server:
       g, broadinstitute:DSP DevOps, role:gh-admin
       g, broadinstitute:jade_prod, role:gh-admin
       g, broadinstitute:jadeteam, role:gh-admin
+controller:
+  nodeSelector:
+    cloud.google.com/gke-nodepool: dev-node
+dex:
+  nodeSelector:
+    cloud.google.com/gke-nodepool: dev-node

--- a/dev/dd/ddDeployment.yaml
+++ b/dev/dd/ddDeployment.yaml
@@ -23,7 +23,7 @@ gcloud-sqlproxy:
 datarepo-api:
   enabled: true
   image:
-    tag: 33eb4d5-develop
+    tag: a0fc3a2-develop
   env:
     GOOGLE_PROJECTID: broad-jade-dd
     DB_DATAREPO_USERNAME: drmanager
@@ -47,7 +47,7 @@ datarepo-api:
 datarepo-ui:
   enabled: true
   image:
-    tag: b2cf0b2-develop
+    tag: 81a5553-develop
   proxyPass:
     status: http://dd-jade-datarepo-api.dd:8080/status
     shutdown: http://dd-jade-datarepo-api.dd:8080/shutdown

--- a/dev/dd/ddDeployment.yaml
+++ b/dev/dd/ddDeployment.yaml
@@ -17,6 +17,8 @@ gcloud-sqlproxy:
     enabled: false
   existingSecret: sqlproxy-sa-dd
   existingSecretKey: sa
+  nodeSelector:
+    cloud.google.com/gke-nodepool: dev-node
 
 datarepo-api:
   enabled: true
@@ -39,6 +41,8 @@ datarepo-api:
   existingStairwayDbSecretKey: "stairwaypassword"
   existingSecretSA: "jade-sa"
   existingServiceAccountSecretKey: "datareposerviceaccount"
+  nodeSelector:
+    cloud.google.com/gke-nodepool: dev-node
 
 datarepo-ui:
   enabled: true
@@ -53,6 +57,8 @@ datarepo-ui:
     create: true
   rbac:
     create: true
+  nodeSelector:
+    cloud.google.com/gke-nodepool: dev-node
 
 oidc-proxy:
   enabled: true
@@ -82,3 +88,5 @@ oidc-proxy:
   rbac:
     create: true
     pspEnabled: true
+  nodeSelector:
+    cloud.google.com/gke-nodepool: dev-node

--- a/dev/deployMultiIntegration.sh
+++ b/dev/deployMultiIntegration.sh
@@ -1,10 +1,12 @@
 #!/bin/bash
 
 NAMESPACES=("dd" "dev" "fb" "jh" "mk" "mm" "ms" "my" "rc" "sh")
-
+helm repo add monster https://broadinstitute.github.io/monster-helm
+helm repo update
 for i in "${NAMESPACES[@]}"
 do
+   helm namespace upgrade ${i}-certificate  monster/gcp-managed-cert --version=0.1.1 --install --namespace ${i} -f "${i}/${i}Managedcert.yaml"
    helm namespace upgrade ${i}-secrets datarepo-helm/create-secret-manager-secret --version=0.0.4 --install --namespace ${i} -f "${i}/${i}Secrets.yaml"
    helm namespace upgrade ${i}-jade datarepo-helm/datarepo --version=0.1.0 --install --namespace ${i} -f "${i}/${i}Deployment.yaml"
-   sleep 10
+   sleep 5
 done

--- a/dev/dev/devDeployment.yaml
+++ b/dev/dev/devDeployment.yaml
@@ -15,6 +15,8 @@ gcloud-sqlproxy:
     enabled: false
   existingSecret: sqlproxy-sa-dev
   existingSecretKey: sa
+  nodeSelector:
+    cloud.google.com/gke-nodepool: dev-node
 datarepo-api:
   enabled: true
   image:
@@ -36,6 +38,8 @@ datarepo-api:
   existingStairwayDbSecretKey: "stairwaypassword"
   existingSecretSA: "jade-sa"
   existingServiceAccountSecretKey: "datareposerviceaccount"
+  nodeSelector:
+    cloud.google.com/gke-nodepool: dev-node
 datarepo-ui:
   enabled: true
   image:
@@ -49,6 +53,8 @@ datarepo-ui:
     create: true
   rbac:
     create: true
+  nodeSelector:
+    cloud.google.com/gke-nodepool: dev-node
 oidc-proxy:
   enabled: true
   env:
@@ -78,3 +84,5 @@ oidc-proxy:
   rbac:
     create: true
     pspEnabled: true
+  nodeSelector:
+    cloud.google.com/gke-nodepool: dev-node

--- a/dev/fb/fbDeployment.yaml
+++ b/dev/fb/fbDeployment.yaml
@@ -17,6 +17,8 @@ gcloud-sqlproxy:
     enabled: false
   existingSecret: sqlproxy-sa-fb
   existingSecretKey: sa
+  nodeSelector:
+    cloud.google.com/gke-nodepool: dev-node
 
 datarepo-api:
   enabled: true
@@ -39,6 +41,8 @@ datarepo-api:
   existingStairwayDbSecretKey: "stairwaypassword"
   existingSecretSA: "jade-sa"
   existingServiceAccountSecretKey: "datareposerviceaccount"
+  nodeSelector:
+    cloud.google.com/gke-nodepool: dev-node
 
 datarepo-ui:
   enabled: true
@@ -53,6 +57,8 @@ datarepo-ui:
     create: true
   rbac:
     create: true
+  nodeSelector:
+    cloud.google.com/gke-nodepool: dev-node
 
 oidc-proxy:
   enabled: true
@@ -68,10 +74,19 @@ oidc-proxy:
   ingress:
     enabled: true
     annotations:
-      globalStaticIpName: jade-dev-fb
+      kubernetes.io/ingress.global-static-ip-name: jade-dev-fb
+      networking.gke.io/managed-certificates: "fb-certificate"
+    tls:
+      - hosts:
+          - jade-fb.datarepo-dev.broadinstitute.org
+    paths:
+      - /*
+    hosts:
+      - jade-fb.datarepo-dev.broadinstitute.org
   serviceAccount:
     create: true
   rbac:
     create: true
     pspEnabled: true
-  existingTlsSecret: oidc-tls-key
+  nodeSelector:
+    cloud.google.com/gke-nodepool: dev-node

--- a/dev/fb/fbDeployment.yaml
+++ b/dev/fb/fbDeployment.yaml
@@ -23,7 +23,7 @@ gcloud-sqlproxy:
 datarepo-api:
   enabled: true
   image:
-    tag: 33eb4d5-develop
+    tag: a0fc3a2-develop
   env:
     GOOGLE_PROJECTID: broad-jade-dev
     DB_DATAREPO_USERNAME: drmanager
@@ -47,7 +47,7 @@ datarepo-api:
 datarepo-ui:
   enabled: true
   image:
-    tag: b2cf0b2-develop
+    tag: 81a5553-develop
   proxyPass:
     status: http://fb-jade-datarepo-api.fb:8080/status
     swagger: http://fb-jade-datarepo-api.fb:8080/swagger-ui.html

--- a/dev/fb/fbManagedcert.yaml
+++ b/dev/fb/fbManagedcert.yaml
@@ -1,0 +1,2 @@
+---
+domainName: jade-fb.datarepo-dev.broadinstitute.org

--- a/dev/fb/fbSecrets.yaml
+++ b/dev/fb/fbSecrets.yaml
@@ -20,11 +20,3 @@ secrets:
       - kubeSecretKey: stairwaypassword
         path: secret/dsde/datarepo/dev/helm-datarepodb-dev
         vaultKey: stairwaypassword
-  - secretName: oidc-tls-key
-    vals:
-      - kubeSecretKey: tls.key
-        path: secret/dsde/datarepo/dev/common/helm-tls-certs
-        vaultKey: tls.key
-      - kubeSecretKey: tls.crt
-        path: secret/dsde/datarepo/dev/common/helm-tls-certs
-        vaultKey: tls.crt

--- a/dev/jh/jhDeployment.yaml
+++ b/dev/jh/jhDeployment.yaml
@@ -23,7 +23,7 @@ gcloud-sqlproxy:
 datarepo-api:
   enabled: true
   image:
-    tag: 33eb4d5-develop
+    tag: a0fc3a2-develop
   env:
     GOOGLE_PROJECTID: broad-jade-dev
     DB_DATAREPO_USERNAME: drmanager
@@ -47,7 +47,7 @@ datarepo-api:
 datarepo-ui:
   enabled: true
   image:
-    tag: b2cf0b2-develop
+    tag: 81a5553-develop
   proxyPass:
     status: http://jh-jade-datarepo-api.jh:8080/status
     swagger: http://jh-jade-datarepo-api.jh:8080/swagger-ui.html

--- a/dev/jh/jhDeployment.yaml
+++ b/dev/jh/jhDeployment.yaml
@@ -17,6 +17,8 @@ gcloud-sqlproxy:
     enabled: false
   existingSecret: sqlproxy-sa-jh
   existingSecretKey: sa
+  nodeSelector:
+    cloud.google.com/gke-nodepool: dev-node
 
 datarepo-api:
   enabled: true
@@ -39,6 +41,8 @@ datarepo-api:
   existingStairwayDbSecretKey: "stairwaypassword"
   existingSecretSA: "jade-sa"
   existingServiceAccountSecretKey: "datareposerviceaccount"
+  nodeSelector:
+    cloud.google.com/gke-nodepool: dev-node
 
 datarepo-ui:
   enabled: true
@@ -53,6 +57,8 @@ datarepo-ui:
     create: true
   rbac:
     create: true
+  nodeSelector:
+    cloud.google.com/gke-nodepool: dev-node
 
 oidc-proxy:
   enabled: true
@@ -68,10 +74,19 @@ oidc-proxy:
   ingress:
     enabled: true
     annotations:
-      globalStaticIpName: jade-dev-jh
+      kubernetes.io/ingress.global-static-ip-name: jade-dev-jh
+      networking.gke.io/managed-certificates: "jh-certificate"
+    tls:
+      - hosts:
+          - jade-jh.datarepo-dev.broadinstitute.org
+    paths:
+      - /*
+    hosts:
+      - jade-jh.datarepo-dev.broadinstitute.org
   serviceAccount:
     create: true
   rbac:
     create: true
     pspEnabled: true
-  existingTlsSecret: oidc-tls-key
+  nodeSelector:
+    cloud.google.com/gke-nodepool: dev-node

--- a/dev/jh/jhManagedcert.yaml
+++ b/dev/jh/jhManagedcert.yaml
@@ -1,0 +1,2 @@
+---
+domainName: jade-jh.datarepo-dev.broadinstitute.org

--- a/dev/jh/jhSecrets.yaml
+++ b/dev/jh/jhSecrets.yaml
@@ -20,11 +20,3 @@ secrets:
       - kubeSecretKey: stairwaypassword
         path: secret/dsde/datarepo/dev/helm-datarepodb-dev
         vaultKey: stairwaypassword
-  - secretName: oidc-tls-key
-    vals:
-      - kubeSecretKey: tls.key
-        path: secret/dsde/datarepo/dev/common/helm-tls-certs
-        vaultKey: tls.key
-      - kubeSecretKey: tls.crt
-        path: secret/dsde/datarepo/dev/common/helm-tls-certs
-        vaultKey: tls.crt

--- a/dev/mk/mkDeployment.yaml
+++ b/dev/mk/mkDeployment.yaml
@@ -23,7 +23,7 @@ gcloud-sqlproxy:
 datarepo-api:
   enabled: true
   image:
-    tag: 33eb4d5-develop
+    tag: a0fc3a2-develop
   env:
     GOOGLE_PROJECTID: broad-jade-my
     DB_DATAREPO_USERNAME: drmanager
@@ -47,7 +47,7 @@ datarepo-api:
 datarepo-ui:
   enabled: true
   image:
-    tag: b2cf0b2-develop
+    tag: 81a5553-develop
   proxyPass:
     status: http://mk-jade-datarepo-api.mk:8080/status
     swagger: http://mk-jade-datarepo-api.mk:8080/swagger-ui.html

--- a/dev/mk/mkDeployment.yaml
+++ b/dev/mk/mkDeployment.yaml
@@ -17,15 +17,17 @@ gcloud-sqlproxy:
     enabled: false
   existingSecret: sqlproxy-sa-mk
   existingSecretKey: sa
+  nodeSelector:
+    cloud.google.com/gke-nodepool: dev-node
 
 datarepo-api:
   enabled: true
   image:
     tag: 33eb4d5-develop
   env:
-    GOOGLE_PROJECTID: broad-jade-my
+    GOOGLE_PROJECTID: broad-jade-dev
     DB_DATAREPO_USERNAME: drmanager
-    SPRING_PROFILES_ACTIVE: google,cloudsql,mk
+    SPRING_PROFILES_ACTIVE: google,cloudsql,dev,mk
     DB_STAIRWAY_USERNAME: drmanager
     DB_STAIRWAY_URI: jdbc:postgresql://mk-jade-gcloud-sqlproxy.mk:5432/stairway-mk
     DB_DATAREPO_URI: jdbc:postgresql://mk-jade-gcloud-sqlproxy.mk:5432/datarepo-mk
@@ -39,6 +41,8 @@ datarepo-api:
   existingStairwayDbSecretKey: "stairwaypassword"
   existingSecretSA: "jade-sa"
   existingServiceAccountSecretKey: "datareposerviceaccount"
+  nodeSelector:
+    cloud.google.com/gke-nodepool: dev-node
 
 datarepo-ui:
   enabled: true
@@ -47,11 +51,14 @@ datarepo-ui:
   proxyPass:
     status: http://mk-jade-datarepo-api.mk:8080/status
     swagger: http://mk-jade-datarepo-api.mk:8080/swagger-ui.html
+    shutdown: http://mk-jade-datarepo-api.mk:8080/shutdown
     api: http://mk-jade-datarepo-api.mk:8080
   serviceAccount:
     create: true
   rbac:
     create: true
+  nodeSelector:
+    cloud.google.com/gke-nodepool: dev-node
 
 oidc-proxy:
   enabled: true
@@ -67,10 +74,19 @@ oidc-proxy:
   ingress:
     enabled: true
     annotations:
-      globalStaticIpName: jade-dev-mk
+      kubernetes.io/ingress.global-static-ip-name: jade-dev-mk
+      networking.gke.io/managed-certificates: "mk-certificate"
+    tls:
+      - hosts:
+          - jade-mk.datarepo-dev.broadinstitute.org
+    paths:
+      - /*
+    hosts:
+      - jade-mk.datarepo-dev.broadinstitute.org
   serviceAccount:
     create: true
   rbac:
     create: true
     pspEnabled: true
-  existingTlsSecret: oidc-tls-key
+  nodeSelector:
+    cloud.google.com/gke-nodepool: dev-node

--- a/dev/mk/mkDeployment.yaml
+++ b/dev/mk/mkDeployment.yaml
@@ -25,7 +25,7 @@ datarepo-api:
   image:
     tag: 33eb4d5-develop
   env:
-    GOOGLE_PROJECTID: broad-jade-dev
+    GOOGLE_PROJECTID: broad-jade-my
     DB_DATAREPO_USERNAME: drmanager
     SPRING_PROFILES_ACTIVE: google,cloudsql,dev,mk
     DB_STAIRWAY_USERNAME: drmanager

--- a/dev/mk/mkManagedcert.yaml
+++ b/dev/mk/mkManagedcert.yaml
@@ -1,0 +1,2 @@
+---
+domainName: jade-mk.datarepo-dev.broadinstitute.org

--- a/dev/mk/mkSecrets.yaml
+++ b/dev/mk/mkSecrets.yaml
@@ -20,11 +20,3 @@ secrets:
       - kubeSecretKey: stairwaypassword
         path: secret/dsde/datarepo/dev/helm-datarepodb-dev
         vaultKey: stairwaypassword
-  - secretName: oidc-tls-key
-    vals:
-      - kubeSecretKey: tls.key
-        path: secret/dsde/datarepo/dev/common/helm-tls-certs
-        vaultKey: tls.key
-      - kubeSecretKey: tls.crt
-        path: secret/dsde/datarepo/dev/common/helm-tls-certs
-        vaultKey: tls.crt

--- a/dev/mm/mmDeployment.yaml
+++ b/dev/mm/mmDeployment.yaml
@@ -23,7 +23,7 @@ gcloud-sqlproxy:
 datarepo-api:
   enabled: true
   image:
-    tag: 33eb4d5-develop
+    tag: a0fc3a2-develop
   env:
     GOOGLE_PROJECTID: broad-jade-mm
     DB_DATAREPO_USERNAME: drmanager
@@ -50,7 +50,7 @@ datarepo-api:
 datarepo-ui:
   enabled: true
   image:
-    tag: b2cf0b2-develop
+    tag: 81a5553-develop
   proxyPass:
     status: http://mm-jade-datarepo-api.mm:8080/status
     swagger: http://mm-jade-datarepo-api.mm:8080/swagger-ui.html

--- a/dev/mm/mmDeployment.yaml
+++ b/dev/mm/mmDeployment.yaml
@@ -17,6 +17,8 @@ gcloud-sqlproxy:
     enabled: false
   existingSecret: sqlproxy-sa-mm
   existingSecretKey: sa
+  nodeSelector:
+    cloud.google.com/gke-nodepool: dev-node
 
 datarepo-api:
   enabled: true
@@ -42,6 +44,8 @@ datarepo-api:
   existingStairwayDbSecretKey: "stairwaypassword"
   existingSecretSA: "jade-sa"
   existingServiceAccountSecretKey: "datareposerviceaccount"
+  nodeSelector:
+    cloud.google.com/gke-nodepool: dev-node
 
 datarepo-ui:
   enabled: true
@@ -55,6 +59,8 @@ datarepo-ui:
     create: true
   rbac:
     create: true
+  nodeSelector:
+    cloud.google.com/gke-nodepool: dev-node
 
 oidc-proxy:
   enabled: true
@@ -70,10 +76,19 @@ oidc-proxy:
   ingress:
     enabled: true
     annotations:
-      globalStaticIpName: jade-dev-mm
+      kubernetes.io/ingress.global-static-ip-name: jade-dev-mm
+      networking.gke.io/managed-certificates: "mm-certificate"
+    tls:
+      - hosts:
+          - jade-mm.datarepo-dev.broadinstitute.org
+    paths:
+      - /*
+    hosts:
+      - jade-mm.datarepo-dev.broadinstitute.org
   serviceAccount:
     create: true
   rbac:
     create: true
     pspEnabled: true
-  existingTlsSecret: oidc-tls-key
+  nodeSelector:
+    cloud.google.com/gke-nodepool: dev-node

--- a/dev/mm/mmManagedcert.yaml
+++ b/dev/mm/mmManagedcert.yaml
@@ -1,0 +1,2 @@
+---
+domainName: jade-mm.datarepo-dev.broadinstitute.org

--- a/dev/mm/mmSecrets.yaml
+++ b/dev/mm/mmSecrets.yaml
@@ -20,11 +20,3 @@ secrets:
       - kubeSecretKey: stairwaypassword
         path: secret/dsde/datarepo/dev/helm-datarepodb-dev
         vaultKey: stairwaypassword
-  - secretName: oidc-tls-key
-    vals:
-      - kubeSecretKey: tls.key
-        path: secret/dsde/datarepo/dev/common/helm-tls-certs
-        vaultKey: tls.key
-      - kubeSecretKey: tls.crt
-        path: secret/dsde/datarepo/dev/common/helm-tls-certs
-        vaultKey: tls.crt

--- a/dev/monitoring/monitoring.yaml
+++ b/dev/monitoring/monitoring.yaml
@@ -1,5 +1,7 @@
 ---
 prometheusOperator:
+  nodeSelector:
+    cloud.google.com/gke-nodepool: dev-node
   createCustomResource: false
 grafana:
   rbac:

--- a/dev/ms/msDeployment.yaml
+++ b/dev/ms/msDeployment.yaml
@@ -17,6 +17,8 @@ gcloud-sqlproxy:
     enabled: false
   existingSecret: sqlproxy-sa-ms
   existingSecretKey: sa
+  nodeSelector:
+    cloud.google.com/gke-nodepool: dev-node
 
 datarepo-api:
   enabled: true
@@ -25,7 +27,7 @@ datarepo-api:
   env:
     GOOGLE_PROJECTID: broad-jade-dev
     DB_DATAREPO_USERNAME: drmanager
-    SPRING_PROFILES_ACTIVE: google,cloudsql,ms
+    SPRING_PROFILES_ACTIVE: google,cloudsql,dev,ms
     DB_STAIRWAY_USERNAME: drmanager
     DB_STAIRWAY_URI: jdbc:postgresql://ms-jade-gcloud-sqlproxy.ms:5432/stairway-ms
     DB_DATAREPO_URI: jdbc:postgresql://ms-jade-gcloud-sqlproxy.ms:5432/datarepo-ms
@@ -39,6 +41,8 @@ datarepo-api:
   existingStairwayDbSecretKey: "stairwaypassword"
   existingSecretSA: "jade-sa"
   existingServiceAccountSecretKey: "datareposerviceaccount"
+  nodeSelector:
+    cloud.google.com/gke-nodepool: dev-node
 
 datarepo-ui:
   enabled: true
@@ -53,6 +57,8 @@ datarepo-ui:
     create: true
   rbac:
     create: true
+  nodeSelector:
+    cloud.google.com/gke-nodepool: dev-node
 
 oidc-proxy:
   enabled: true
@@ -82,3 +88,5 @@ oidc-proxy:
   rbac:
     create: true
     pspEnabled: true
+  nodeSelector:
+    cloud.google.com/gke-nodepool: dev-node

--- a/dev/ms/msDeployment.yaml
+++ b/dev/ms/msDeployment.yaml
@@ -23,7 +23,7 @@ gcloud-sqlproxy:
 datarepo-api:
   enabled: true
   image:
-    tag: 33eb4d5-develop
+    tag: a0fc3a2-develop
   env:
     GOOGLE_PROJECTID: broad-jade-dev
     DB_DATAREPO_USERNAME: drmanager
@@ -47,7 +47,7 @@ datarepo-api:
 datarepo-ui:
   enabled: true
   image:
-    tag: b2cf0b2-develop
+    tag: 81a5553-develop
   proxyPass:
     status: http://ms-jade-datarepo-api.ms:8080/status
     swagger: http://ms-jade-datarepo-api.ms:8080/swagger-ui.html

--- a/dev/ms/msManagedcert.yaml
+++ b/dev/ms/msManagedcert.yaml
@@ -1,2 +1,2 @@
 ---
-domainName: jade-my.datarepo-dev.broadinstitute.org
+domainName: jade-ms.datarepo-dev.broadinstitute.org

--- a/dev/ms/msManagedcert.yaml
+++ b/dev/ms/msManagedcert.yaml
@@ -1,2 +1,2 @@
 ---
-domainName: jade-ms.datarepo-dev.broadinstitute.org
+domainName: jade-my.datarepo-dev.broadinstitute.org

--- a/dev/my/myDeployment.yaml
+++ b/dev/my/myDeployment.yaml
@@ -25,7 +25,7 @@ datarepo-api:
   image:
     tag: 33eb4d5-develop
   env:
-    GOOGLE_PROJECTID: broad-jade-dev
+    GOOGLE_PROJECTID: broad-jade-my
     DB_DATAREPO_USERNAME: drmanager
     SPRING_PROFILES_ACTIVE: google,cloudsql,dev,my
     DB_STAIRWAY_USERNAME: drmanager

--- a/dev/my/myDeployment.yaml
+++ b/dev/my/myDeployment.yaml
@@ -23,7 +23,7 @@ gcloud-sqlproxy:
 datarepo-api:
   enabled: true
   image:
-    tag: 33eb4d5-develop
+    tag: a0fc3a2-develop
   env:
     GOOGLE_PROJECTID: broad-jade-my
     DB_DATAREPO_USERNAME: drmanager
@@ -47,7 +47,7 @@ datarepo-api:
 datarepo-ui:
   enabled: true
   image:
-    tag: b2cf0b2-develop
+    tag: 81a5553-develop
   proxyPass:
     status: http://my-jade-datarepo-api.my:8080/status
     swagger: http://my-jade-datarepo-api.my:8080/swagger-ui.html

--- a/dev/my/myDeployment.yaml
+++ b/dev/my/myDeployment.yaml
@@ -17,15 +17,17 @@ gcloud-sqlproxy:
     enabled: false
   existingSecret: sqlproxy-sa-my
   existingSecretKey: sa
+  nodeSelector:
+    cloud.google.com/gke-nodepool: dev-node
 
 datarepo-api:
   enabled: true
   image:
     tag: 33eb4d5-develop
   env:
-    GOOGLE_PROJECTID: broad-jade-my
+    GOOGLE_PROJECTID: broad-jade-dev
     DB_DATAREPO_USERNAME: drmanager
-    SPRING_PROFILES_ACTIVE: google,cloudsql,my
+    SPRING_PROFILES_ACTIVE: google,cloudsql,dev,my
     DB_STAIRWAY_USERNAME: drmanager
     DB_STAIRWAY_URI: jdbc:postgresql://my-jade-gcloud-sqlproxy.my:5432/stairway-my
     DB_DATAREPO_URI: jdbc:postgresql://my-jade-gcloud-sqlproxy.my:5432/datarepo-my
@@ -39,6 +41,8 @@ datarepo-api:
   existingStairwayDbSecretKey: "stairwaypassword"
   existingSecretSA: "jade-sa"
   existingServiceAccountSecretKey: "datareposerviceaccount"
+  nodeSelector:
+    cloud.google.com/gke-nodepool: dev-node
 
 datarepo-ui:
   enabled: true
@@ -47,11 +51,14 @@ datarepo-ui:
   proxyPass:
     status: http://my-jade-datarepo-api.my:8080/status
     swagger: http://my-jade-datarepo-api.my:8080/swagger-ui.html
+    shutdown: http://my-jade-datarepo-api.my:8080/shutdown
     api: http://my-jade-datarepo-api.my:8080
   serviceAccount:
     create: true
   rbac:
     create: true
+  nodeSelector:
+    cloud.google.com/gke-nodepool: dev-node
 
 oidc-proxy:
   enabled: true
@@ -67,10 +74,19 @@ oidc-proxy:
   ingress:
     enabled: true
     annotations:
-      globalStaticIpName: jade-dev-my
+      kubernetes.io/ingress.global-static-ip-name: jade-dev-my
+      networking.gke.io/managed-certificates: "my-certificate"
+    tls:
+      - hosts:
+          - jade-my.datarepo-dev.broadinstitute.org
+    paths:
+      - /*
+    hosts:
+      - jade-my.datarepo-dev.broadinstitute.org
   serviceAccount:
     create: true
   rbac:
     create: true
     pspEnabled: true
-  existingTlsSecret: oidc-tls-key
+  nodeSelector:
+    cloud.google.com/gke-nodepool: dev-node

--- a/dev/my/myManagedcert.yaml
+++ b/dev/my/myManagedcert.yaml
@@ -1,0 +1,2 @@
+---
+domainName: jade-ms.datarepo-dev.broadinstitute.org

--- a/dev/my/myManagedcert.yaml
+++ b/dev/my/myManagedcert.yaml
@@ -1,2 +1,2 @@
 ---
-domainName: jade-ms.datarepo-dev.broadinstitute.org
+domainName: jade-my.datarepo-dev.broadinstitute.org

--- a/dev/my/mySecrets.yaml
+++ b/dev/my/mySecrets.yaml
@@ -20,11 +20,3 @@ secrets:
       - kubeSecretKey: stairwaypassword
         path: secret/dsde/datarepo/dev/helm-datarepodb-dev
         vaultKey: stairwaypassword
-  - secretName: oidc-tls-key
-    vals:
-      - kubeSecretKey: tls.key
-        path: secret/dsde/datarepo/dev/common/helm-tls-certs
-        vaultKey: tls.key
-      - kubeSecretKey: tls.crt
-        path: secret/dsde/datarepo/dev/common/helm-tls-certs
-        vaultKey: tls.crt

--- a/dev/rc/rcDeployment.yaml
+++ b/dev/rc/rcDeployment.yaml
@@ -25,7 +25,7 @@ datarepo-api:
   image:
     tag: 33eb4d5-develop
   env:
-    GOOGLE_PROJECTID: broad-jade-dev
+    GOOGLE_PROJECTID: broad-jade-rc
     DB_DATAREPO_USERNAME: drmanager
     SPRING_PROFILES_ACTIVE: google,cloudsql,dev,rc
     DB_STAIRWAY_USERNAME: drmanager

--- a/dev/rc/rcDeployment.yaml
+++ b/dev/rc/rcDeployment.yaml
@@ -17,15 +17,17 @@ gcloud-sqlproxy:
     enabled: false
   existingSecret: sqlproxy-sa-rc
   existingSecretKey: sa
+  nodeSelector:
+    cloud.google.com/gke-nodepool: dev-node
 
 datarepo-api:
   enabled: true
   image:
     tag: 33eb4d5-develop
   env:
-    GOOGLE_PROJECTID: broad-jade-rc
+    GOOGLE_PROJECTID: broad-jade-dev
     DB_DATAREPO_USERNAME: drmanager
-    SPRING_PROFILES_ACTIVE: google,cloudsql,rc
+    SPRING_PROFILES_ACTIVE: google,cloudsql,dev,rc
     DB_STAIRWAY_USERNAME: drmanager
     DB_STAIRWAY_URI: jdbc:postgresql://rc-jade-gcloud-sqlproxy.rc:5432/stairway-rc
     DB_DATAREPO_URI: jdbc:postgresql://rc-jade-gcloud-sqlproxy.rc:5432/datarepo-rc
@@ -39,6 +41,8 @@ datarepo-api:
   existingStairwayDbSecretKey: "stairwaypassword"
   existingSecretSA: "jade-sa"
   existingServiceAccountSecretKey: "datareposerviceaccount"
+  nodeSelector:
+    cloud.google.com/gke-nodepool: dev-node
 
 datarepo-ui:
   enabled: true
@@ -46,13 +50,15 @@ datarepo-ui:
     tag: b2cf0b2-develop
   proxyPass:
     status: http://rc-jade-datarepo-api.rc:8080/status
-    shutdown: http://rc-jade-datarepo-api.rc:8080/shutdown
     swagger: http://rc-jade-datarepo-api.rc:8080/swagger-ui.html
+    shutdown: http://rc-jade-datarepo-api.rc:8080/shutdown
     api: http://rc-jade-datarepo-api.rc:8080
   serviceAccount:
     create: true
   rbac:
     create: true
+  nodeSelector:
+    cloud.google.com/gke-nodepool: dev-node
 
 oidc-proxy:
   enabled: true
@@ -68,10 +74,19 @@ oidc-proxy:
   ingress:
     enabled: true
     annotations:
-      globalStaticIpName: jade-dev-rc
+      kubernetes.io/ingress.global-static-ip-name: jade-dev-rc
+      networking.gke.io/managed-certificates: "rc-certificate"
+    tls:
+      - hosts:
+          - jade-rc.datarepo-dev.broadinstitute.org
+    paths:
+      - /*
+    hosts:
+      - jade-rc.datarepo-dev.broadinstitute.org
   serviceAccount:
     create: true
   rbac:
     create: true
     pspEnabled: true
-  existingTlsSecret: oidc-tls-key
+  nodeSelector:
+    cloud.google.com/gke-nodepool: dev-node

--- a/dev/rc/rcDeployment.yaml
+++ b/dev/rc/rcDeployment.yaml
@@ -23,7 +23,7 @@ gcloud-sqlproxy:
 datarepo-api:
   enabled: true
   image:
-    tag: 33eb4d5-develop
+    tag: a0fc3a2-develop
   env:
     GOOGLE_PROJECTID: broad-jade-rc
     DB_DATAREPO_USERNAME: drmanager
@@ -47,7 +47,7 @@ datarepo-api:
 datarepo-ui:
   enabled: true
   image:
-    tag: b2cf0b2-develop
+    tag: 81a5553-develop
   proxyPass:
     status: http://rc-jade-datarepo-api.rc:8080/status
     swagger: http://rc-jade-datarepo-api.rc:8080/swagger-ui.html

--- a/dev/rc/rcManagedcert.yaml
+++ b/dev/rc/rcManagedcert.yaml
@@ -1,0 +1,2 @@
+---
+domainName: jade-rc.datarepo-dev.broadinstitute.org

--- a/dev/rc/rcSecrets.yaml
+++ b/dev/rc/rcSecrets.yaml
@@ -20,11 +20,3 @@ secrets:
       - kubeSecretKey: stairwaypassword
         path: secret/dsde/datarepo/dev/helm-datarepodb-dev
         vaultKey: stairwaypassword
-  - secretName: oidc-tls-key
-    vals:
-      - kubeSecretKey: tls.key
-        path: secret/dsde/datarepo/dev/common/helm-tls-certs
-        vaultKey: tls.key
-      - kubeSecretKey: tls.crt
-        path: secret/dsde/datarepo/dev/common/helm-tls-certs
-        vaultKey: tls.crt

--- a/dev/sh/shDeployment.yaml
+++ b/dev/sh/shDeployment.yaml
@@ -17,6 +17,8 @@ gcloud-sqlproxy:
     enabled: false
   existingSecret: sqlproxy-sa-sh
   existingSecretKey: sa
+  nodeSelector:
+    cloud.google.com/gke-nodepool: dev-node
 
 datarepo-api:
   enabled: true
@@ -39,6 +41,8 @@ datarepo-api:
   existingStairwayDbSecretKey: "stairwaypassword"
   existingSecretSA: "jade-sa"
   existingServiceAccountSecretKey: "datareposerviceaccount"
+  nodeSelector:
+    cloud.google.com/gke-nodepool: dev-node
 
 datarepo-ui:
   enabled: true
@@ -46,13 +50,15 @@ datarepo-ui:
     tag: b2cf0b2-develop
   proxyPass:
     status: http://sh-jade-datarepo-api.sh:8080/status
-    shutdown: http://sh-jade-datarepo-api.sh:8080/shutdown
     swagger: http://sh-jade-datarepo-api.sh:8080/swagger-ui.html
+    shutdown: http://sh-jade-datarepo-api.sh:8080/shutdown
     api: http://sh-jade-datarepo-api.sh:8080
   serviceAccount:
     create: true
   rbac:
     create: true
+  nodeSelector:
+    cloud.google.com/gke-nodepool: dev-node
 
 oidc-proxy:
   enabled: true
@@ -68,10 +74,19 @@ oidc-proxy:
   ingress:
     enabled: true
     annotations:
-      globalStaticIpName: jade-dev-sh
+      kubernetes.io/ingress.global-static-ip-name: jade-dev-sh
+      networking.gke.io/managed-certificates: "sh-certificate"
+    tls:
+      - hosts:
+          - jade-sh.datarepo-dev.broadinstitute.org
+    paths:
+      - /*
+    hosts:
+      - jade-sh.datarepo-dev.broadinstitute.org
   serviceAccount:
     create: true
   rbac:
     create: true
     pspEnabled: true
-  existingTlsSecret: oidc-tls-key
+  nodeSelector:
+    cloud.google.com/gke-nodepool: dev-node

--- a/dev/sh/shDeployment.yaml
+++ b/dev/sh/shDeployment.yaml
@@ -23,7 +23,7 @@ gcloud-sqlproxy:
 datarepo-api:
   enabled: true
   image:
-    tag: 33eb4d5-develop
+    tag: a0fc3a2-develop
   env:
     GOOGLE_PROJECTID: broad-jade-dev
     DB_DATAREPO_USERNAME: drmanager
@@ -47,7 +47,7 @@ datarepo-api:
 datarepo-ui:
   enabled: true
   image:
-    tag: b2cf0b2-develop
+    tag: 81a5553-develop
   proxyPass:
     status: http://sh-jade-datarepo-api.sh:8080/status
     swagger: http://sh-jade-datarepo-api.sh:8080/swagger-ui.html

--- a/dev/sh/shManagedcert.yaml
+++ b/dev/sh/shManagedcert.yaml
@@ -1,0 +1,2 @@
+---
+domainName: jade-sh.datarepo-dev.broadinstitute.org

--- a/dev/sh/shSecrets.yaml
+++ b/dev/sh/shSecrets.yaml
@@ -20,11 +20,3 @@ secrets:
       - kubeSecretKey: stairwaypassword
         path: secret/dsde/datarepo/dev/helm-datarepodb-dev
         vaultKey: stairwaypassword
-  - secretName: oidc-tls-key
-    vals:
-      - kubeSecretKey: tls.key
-        path: secret/dsde/datarepo/dev/common/helm-tls-certs
-        vaultKey: tls.key
-      - kubeSecretKey: tls.crt
-        path: secret/dsde/datarepo/dev/common/helm-tls-certs
-        vaultKey: tls.crt


### PR DESCRIPTION
A lot people have not been updating their environment so I took the liberty to do this myself. I don't typically enjoy doing this but it seems needed to get all in sync. For some this added the following:

- Shutdown path in api chart
- managed cert chart from monster
- reworked oidc to use managed cert
- added terra labels
- nodeSelector for all charts for kubernetes administration ease of use
-  added anti/affinity field capability
-  added resource field capability
-  added tolerances field capability

I'd like as many reviews on this as possible as it will affect all. When this is applied the `<chart>.image.tag` field will deploy what ever is in there so your local build will disappear. I will be applying this after hours so ideally you can do a `skaffold run` to fix in the AM. Note: your `skaffold.yaml` will need to be updated similarly to the template in develop. 