### PR TITLE
DD chart separation

### DIFF
--- a/dev/dd/create-secret-manager-secret.yaml
+++ b/dev/dd/create-secret-manager-secret.yaml
@@ -1,0 +1,16 @@
+---
+secrets:
+  - secretName: jade-sa
+    vals:
+      - kubeSecretKey: datareposerviceaccount
+        path: secret/dsde/datarepo/dev/sa-key-b64
+        encoding: base64
+        vaultKey: sa
+  - secretName: database-pwd-dd
+    vals:
+      - kubeSecretKey: datarepopassword
+        path: secret/dsde/datarepo/dev/helm-datarepodb-dev
+        vaultKey: datarepopassword
+      - kubeSecretKey: stairwaypassword
+        path: secret/dsde/datarepo/dev/helm-datarepodb-dev
+        vaultKey: stairwaypassword

--- a/dev/dd/datarepo-api.yaml
+++ b/dev/dd/datarepo-api.yaml
@@ -1,0 +1,22 @@
+---
+image:
+  tag: a0fc3a2-develop
+env:
+  GOOGLE_PROJECTID: broad-jade-dd
+  DB_DATAREPO_USERNAME: drmanager
+  SPRING_PROFILES_ACTIVE: google,cloudsql,dev,dd
+  DB_STAIRWAY_USERNAME: drmanager
+  DB_STAIRWAY_URI: jdbc:postgresql://dd-jade-gcloud-sqlproxy.dd:5432/stairway-dd
+  DB_DATAREPO_URI: jdbc:postgresql://dd-jade-gcloud-sqlproxy.dd:5432/datarepo-dd
+serviceAccount:
+  create: true
+rbac:
+  create: true
+  pspEnabled: true
+existingSecretDB: "database-pwd-dd"
+existingDatarepoDbSecretKey: "datarepopassword"
+existingStairwayDbSecretKey: "stairwaypassword"
+existingSecretSA: "jade-sa"
+existingServiceAccountSecretKey: "datareposerviceaccount"
+nodeSelector:
+  cloud.google.com/gke-nodepool: dev-node

--- a/dev/dd/datarepo-ui.yaml
+++ b/dev/dd/datarepo-ui.yaml
@@ -1,0 +1,14 @@
+---
+image:
+  tag: 81a5553-develop
+proxyPass:
+  status: http://dd-jade-datarepo-api.dd:8080/status
+  shutdown: http://dd-jade-datarepo-api.dd:8080/shutdown
+  swagger: http://dd-jade-datarepo-api.dd:8080/swagger-ui.html
+  api: http://dd-jade-datarepo-api.dd:8080
+serviceAccount:
+  create: true
+rbac:
+  create: true
+nodeSelector:
+  cloud.google.com/gke-nodepool: dev-node

--- a/dev/dd/deploy.sh
+++ b/dev/dd/deploy.sh
@@ -7,6 +7,6 @@ relase_name=${namespace}-jade
 helm repo update
 for i in "${charts[@]}"
 do
-   helm namespace upgrade ${relase_name}-${i} datarepo-helm/${i} --install --namespace ${namespace} -f "${i}.yaml --dry-run"
+   helm namespace upgrade ${relase_name}-${i} datarepo-helm/${i} --install --namespace ${namespace} -f "${i}.yaml"
    sleep 5
 done

--- a/dev/dd/deploy.sh
+++ b/dev/dd/deploy.sh
@@ -1,4 +1,12 @@
 #!/bin/bash
 
-helm namespace upgrade dd-secrets datarepo-helm/create-secret-manager-secret --version=0.0.4 --install --namespace dd -f ddSecrets.yaml
-helm namespace upgrade dd-jade datarepo-helm/datarepo --version=0.1.7 --install --namespace dd -f ddDeployment.yaml
+charts=("create-secret-manager-secret" "gcloud-sqlproxy" "datarepo-api" "datarepo-ui" "oidc-proxy")
+namespace=dd
+relase_name=${namespace}-jade
+
+helm repo update
+for i in "${charts[@]}"
+do
+   helm namespace upgrade ${relase_name}-${i} datarepo-helm/${i} --install --namespace ${namespace} -f "${i}.yaml --dry-run"
+   sleep 5
+done

--- a/dev/dd/gcloud-sqlproxy.yaml
+++ b/dev/dd/gcloud-sqlproxy.yaml
@@ -1,0 +1,19 @@
+---
+enabled: true
+googleServiceAccount: dd-proxy-sa@broad-jade-dev.iam.gserviceaccount.com
+cloudsql:
+  instances:
+    # GCP instance name.
+    - instance: "jade-postgres-11-8a00fd4d3b"
+      # GCP project where the instance exists.
+      project: "broad-jade-dev"
+      # GCP region where the instance exists.
+      region: "us-central1"
+      # Port number for the proxy to expose for this instance.
+      port: 5432
+rbac:
+  create: true
+networkPolicy:
+  enabled: false
+nodeSelector:
+  cloud.google.com/gke-nodepool: dev-node

--- a/dev/dd/oidc-proxy.yaml
+++ b/dev/dd/oidc-proxy.yaml
@@ -1,0 +1,29 @@
+---
+env:
+  PROXY_URL: http://dd-jade-datarepo-ui.dd:80/
+  PROXY_URL2: http://dd-jade-datarepo-api.dd:8080/api
+  PROXY_URL3: http://dd-jade-datarepo-api.dd:8080/register
+  LOG_LEVEL: debug
+  SERVER_NAME: jade.datarepo-dev.broadinstitute.org
+  REMOTE_USER_CLAIM: sub
+  ENABLE_STACKDRIVER: yes
+  FILTER2: AddOutputFilterByType DEFLATE application/json text/plain text/html application/javascript application/x-javascript
+ingress:
+  enabled: true
+  domainName: jade-dd.datarepo-dev.broadinstitute.org
+  annotations:
+    kubernetes.io/ingress.global-static-ip-name: jade-dev-dd
+  tls:
+    - hosts:
+        - jade-dd.datarepo-dev.broadinstitute.org
+  paths:
+    - /*
+  hosts:
+    - jade-dd.datarepo-dev.broadinstitute.org
+serviceAccount:
+  create: true
+rbac:
+  create: true
+  pspEnabled: true
+nodeSelector:
+  cloud.google.com/gke-nodepool: dev-node

--- a/dev/dd/skaffold.yaml
+++ b/dev/dd/skaffold.yaml
@@ -1,0 +1,62 @@
+## DD env specific skaffold.yaml
+apiVersion: skaffold/v2alpha2
+kind: Config
+build:
+  tagPolicy:
+    gitCommit:
+      variant: AbbrevCommitSha
+  artifacts:
+  - image: gcr.io/broad-jade-dev/jade-data-repo
+    jib:
+      args:
+      - jib
+      type: gradle
+deploy:
+  helm:
+    flags:
+      upgrade:
+        - --install
+        - --debug
+    releases:
+# create secrets
+    - name: dd-jade-create-secret-manager-secret
+      chartPath: https://github.com/broadinstitute/datarepo-helm/releases/download/create-secret-manager-secret-0.0.4/create-secret-manager-secret-0.0.4.tgz
+      version: 0.0.4
+      namespace: dd
+      remote: true
+      valuesFiles:
+      - https://raw.githubusercontent.com/broadinstitute/datarepo-helm-definitions/master/dev/dd/create-secret-manager-secret.yaml
+# gcp sqlproxy
+    - name: dd-jade-gcloud-sqlproxy
+      chartPath: https://github.com/broadinstitute/datarepo-helm/releases/download/gcloud-sqlproxy-0.19.5/datarepo-0.19.5.tgz
+      version: 0.19.5
+      namespace: dd
+      remote: true
+      valuesFiles:
+      - https://raw.githubusercontent.com/broadinstitute/datarepo-helm-definitions/master/dev/dd/gcloud-sqlproxy.yaml
+# datarepo-api
+    - name: dd-jade-datarepo-api
+      chartPath: https://github.com/broadinstitute/datarepo-helm/releases/download/datarepo-api-0.0.14/datarepo-api-0.0.14.tgz
+      version: 0.0.14
+      namespace: dd
+      remote: true
+      values:
+        imageName: gcr.io/broad-jade-dev/jade-data-repo
+      valuesFiles:
+      - https://raw.githubusercontent.com/broadinstitute/datarepo-helm-definitions/master/dev/dd/datarepo-api.yaml
+# datarepo-ui
+    - name: dd-jade-datarepo-ui
+      chartPath: https://github.com/broadinstitute/datarepo-helm/releases/download/datarepo-ui-0.0.6/datarepo-ui-0.0.6.tgz
+      version: 0.0.6
+      namespace: dd
+      remote: true
+      valuesFiles:
+      - https://raw.githubusercontent.com/broadinstitute/datarepo-helm-definitions/master/dev/dd/datarepo-ui.yaml
+# oidc-proxy
+    - name: dd-jade-oidc-proxy
+      chartPath: https://github.com/broadinstitute/datarepo-helm/releases/download/oidc-proxy-0.0.8/oidc-proxy-0.0.8.tgz
+      version: 0.0.8
+      namespace: dd
+      remote: true
+      valuesFiles:
+      - https://raw.githubusercontent.com/broadinstitute/datarepo-helm-definitions/master/dev/dd/oidc-proxy.yaml


### PR DESCRIPTION
This will make the upgrade all env's process longer in the future but might be the way to go for all developers vs the umbrella chart. @ddietterich can be our guinea pig for testing this sort of config. 

```
▶ helm ls -n dd
NAME                                    NAMESPACE       REVISION        UPDATED                                 STATUS          CHART                                   APP VERSION
dd-jade-create-secret-manager-secret    dd              3               2020-05-27 17:28:19.138686 -0400 EDT    deployed        create-secret-manager-secret-0.0.4                 
dd-jade-datarepo-api                    dd              2               2020-05-27 17:28:30.457283 -0400 EDT    deployed        datarepo-api-0.0.14                     0.0.14     
dd-jade-datarepo-ui                     dd              2               2020-05-27 17:28:36.977399 -0400 EDT    deployed        datarepo-ui-0.0.6                       0.0.6      
dd-jade-gcloud-sqlproxy                 dd              2               2020-05-27 17:28:24.079344 -0400 EDT    deployed        gcloud-sqlproxy-0.19.5                  1.16       
dd-jade-oidc-proxy                      dd              2               2020-05-27 17:28:43.109552 -0400 EDT    deployed        oidc-proxy-0.0.8                        0.0.8   
```