### PR TITLE
DR-1081: Override google.singleDataProjectId env var for integration 3,4,5,temp.

### DIFF
--- a/integration/integration-3/integration-3Deployment.yaml
+++ b/integration/integration-3/integration-3Deployment.yaml
@@ -21,7 +21,8 @@ datarepo-api:
   image:
     tag: 68ec114-develop
   env:
-    GOOGLE_PROJECTID: broad-jade-int-3
+    GOOGLE_PROJECTID: broad-jade-integration
+    GOOGLE_SINGLEDATAPROJECTID: broad-jade-int-3-data
     DB_DATAREPO_USERNAME: drmanager
     SPRING_PROFILES_ACTIVE: google,cloudsql,integration
     DB_STAIRWAY_USERNAME: drmanager

--- a/integration/integration-4/integration-4Deployment.yaml
+++ b/integration/integration-4/integration-4Deployment.yaml
@@ -22,6 +22,7 @@ datarepo-api:
     tag: 1b98dd5-develop
   env:
     GOOGLE_PROJECTID: broad-jade-integration
+    GOOGLE_SINGLEDATAPROJECTID: broad-jade-int-4-data
     DB_DATAREPO_USERNAME: drmanager
     SPRING_PROFILES_ACTIVE: google,cloudsql
     DB_STAIRWAY_USERNAME: drmanager

--- a/integration/integration-5/integration-5Deployment.yaml
+++ b/integration/integration-5/integration-5Deployment.yaml
@@ -22,6 +22,7 @@ datarepo-api:
     tag: 1b98dd5-develop
   env:
     GOOGLE_PROJECTID: broad-jade-integration
+    GOOGLE_SINGLEDATAPROJECTID: broad-jade-int-5-data
     DB_DATAREPO_USERNAME: drmanager
     SPRING_PROFILES_ACTIVE: google,cloudsql
     DB_STAIRWAY_USERNAME: drmanager

--- a/integration/integration-temp/datarepo-api.yaml
+++ b/integration/integration-temp/datarepo-api.yaml
@@ -4,6 +4,7 @@ image:
   tag: ca9bd61-develop
 env:
   GOOGLE_PROJECTID: broad-jade-integration
+  GOOGLE_SINGLEDATAPROJECTID: broad-jade-integration-data
   DB_DATAREPO_USERNAME: drmanager
   SPRING_PROFILES_ACTIVE: google,cloudsql,temp
   DB_STAIRWAY_USERNAME: drmanager


### PR DESCRIPTION
Set the data project for the below integration environments:
  integration-3: broad-jade-int-3-data
  integration-4: broad-jade-int-4-data
  integration-5: broad-jade-int-5-data
  integration-temp: broad-jade-integration-data
