### PR TITLE
Perf Datarepo version update: 1.0.97

### DIFF
--- a/perf/datarepo-api.yaml
+++ b/perf/datarepo-api.yaml
@@ -1,6 +1,5 @@
----
 image:
-  tag: a5c9351-develop
+  tag: 1.0.97
 env:
   GOOGLE_PROJECTID: broad-jade-perf
   GOOGLE_SINGLEDATAPROJECTID: broad-jade-perf-data2


### PR DESCRIPTION
Update versions in **1.0.97**.
*Note: This PR was opened by the [update-env GitHub Actions workflow](https://github.com/DataBiosphere/jade-data-repo/actions/runs/269561316).*