### PR TITLE
Perf Datarepo version update: $LATEST_GITHASH

### DIFF
--- a/perf/datarepo-api.yaml
+++ b/perf/datarepo-api.yaml
@@ -1,5 +1,5 @@
 image:
-  tag: c8e41b0
+  tag: $LATEST_GITHASH
 env:
   GOOGLE_PROJECTID: broad-jade-perf
   GOOGLE_SINGLEDATAPROJECTID: broad-jade-perf-data2


### PR DESCRIPTION
Update versions in perf env to reflect image tag $LATEST_GITHASH.
*Note: This PR was opened by the [update-env GitHub Actions workflow](https://github.com/DataBiosphere/jade-data-repo/actions/runs/279296655).*