### PR TITLE
Perf Datarepo version update: 3144c56

### DIFF
--- a/perf/datarepo-api.yaml
+++ b/perf/datarepo-api.yaml
@@ -1,5 +1,5 @@
 image:
-  tag: c8e41b0
+  tag: 3144c56
 env:
   GOOGLE_PROJECTID: broad-jade-perf
   GOOGLE_SINGLEDATAPROJECTID: broad-jade-perf-data2


### PR DESCRIPTION
Update versions in perf env to reflect image tag 3144c56.
*Note: This PR was opened by the [test-runner-perf GitHub Actions workflow](https://github.com/DataBiosphere/jade-data-repo/actions/runs/280897591).*