### PR TITLE
Perf Datarepo version update: 70f3c91

### DIFF
--- a/perf/datarepo-api.yaml
+++ b/perf/datarepo-api.yaml
@@ -1,5 +1,5 @@
 image:
-  tag: 1a52af1
+  tag: 70f3c91
 env:
   GOOGLE_PROJECTID: broad-jade-perf
   GOOGLE_SINGLEDATAPROJECTID: broad-jade-perf-data2


### PR DESCRIPTION
Update versions in perf env to reflect image tag 70f3c91.
*Note: This PR was opened by the [test-runner-perf GitHub Actions workflow](https://github.com/DataBiosphere/jade-data-repo/actions/runs/291982240).*