### PR TITLE
DR-1382 Use new node pools and run dev with 3 replicas

### DIFF
--- a/dev/dev/devDeployment.yaml
+++ b/dev/dev/devDeployment.yaml
@@ -16,7 +16,7 @@ gcloud-sqlproxy:
   existingSecret: sqlproxy-sa-dev
   existingSecretKey: sa
   nodeSelector:
-    cloud.google.com/gke-nodepool: dev-node
+    cloud.google.com/gke-nodepool: dev-node-2
 datarepo-api:
   enabled: true
   image:
@@ -42,7 +42,7 @@ datarepo-api:
   existingSecretSA: "jade-sa"
   existingServiceAccountSecretKey: "datareposerviceaccount"
   nodeSelector:
-    cloud.google.com/gke-nodepool: dev-node
+    cloud.google.com/gke-nodepool: dev-node-2
 datarepo-ui:
   enabled: true
   image:
@@ -57,7 +57,7 @@ datarepo-ui:
   rbac:
     create: true
   nodeSelector:
-    cloud.google.com/gke-nodepool: dev-node
+    cloud.google.com/gke-nodepool: dev-node-2
 oidc-proxy:
   enabled: true
   env:
@@ -88,4 +88,4 @@ oidc-proxy:
     create: true
     pspEnabled: true
   nodeSelector:
-    cloud.google.com/gke-nodepool: dev-node
+    cloud.google.com/gke-nodepool: dev-node-2

--- a/dev/dev/devDeployment.yaml
+++ b/dev/dev/devDeployment.yaml
@@ -43,6 +43,7 @@ datarepo-api:
   existingServiceAccountSecretKey: "datareposerviceaccount"
   nodeSelector:
     cloud.google.com/gke-nodepool: dev-node-2
+  replicas: 3
 datarepo-ui:
   enabled: true
   image:

--- a/integration/integration-2/datarepo-api.yaml
+++ b/integration/integration-2/datarepo-api.yaml
@@ -24,4 +24,4 @@ existingStairwayDbSecretKey: "stairwaypassword"
 existingSecretSA: "jade-sa"
 existingServiceAccountSecretKey: "datareposerviceaccount"
 nodeSelector:
-  cloud.google.com/gke-nodepool: integration-node
+  cloud.google.com/gke-nodepool: integration-node-2

--- a/integration/integration-2/datarepo-ui.yaml
+++ b/integration/integration-2/datarepo-ui.yaml
@@ -11,4 +11,4 @@ serviceAccount:
 rbac:
   create: true
 nodeSelector:
-  cloud.google.com/gke-nodepool: integration-node
+  cloud.google.com/gke-nodepool: integration-node-2

--- a/integration/integration-2/gcloud-sqlproxy.yaml
+++ b/integration/integration-2/gcloud-sqlproxy.yaml
@@ -14,4 +14,4 @@ rbac:
 networkPolicy:
   enabled: false
 nodeSelector:
- cloud.google.com/gke-nodepool: integration-node
+ cloud.google.com/gke-nodepool: integration-node-2

--- a/integration/integration-2/integration-2Deployment.yaml
+++ b/integration/integration-2/integration-2Deployment.yaml
@@ -15,7 +15,7 @@ gcloud-sqlproxy:
   networkPolicy:
     enabled: false
   nodeSelector:
-    cloud.google.com/gke-nodepool: integration-node
+    cloud.google.com/gke-nodepool: integration-node-2
 datarepo-api:
   enabled: true
   image:
@@ -41,7 +41,7 @@ datarepo-api:
   existingSecretSA: "jade-sa"
   existingServiceAccountSecretKey: "datareposerviceaccount"
   nodeSelector:
-    cloud.google.com/gke-nodepool: integration-node
+    cloud.google.com/gke-nodepool: integration-node-2
 datarepo-ui:
   enabled: true
   image:
@@ -56,7 +56,7 @@ datarepo-ui:
   rbac:
     create: true
   nodeSelector:
-    cloud.google.com/gke-nodepool: integration-node
+    cloud.google.com/gke-nodepool: integration-node-2
 oidc-proxy:
   enabled: true
   replicaCount: 1
@@ -89,4 +89,4 @@ oidc-proxy:
     pspEnabled: true
   existingTlsSecret: oidc-tls-key
   nodeSelector:
-    cloud.google.com/gke-nodepool: integration-node
+    cloud.google.com/gke-nodepool: integration-node-2

--- a/integration/integration-2/oidc-proxy.yaml
+++ b/integration/integration-2/oidc-proxy.yaml
@@ -28,4 +28,4 @@ rbac:
   create: true
   pspEnabled: true
 nodeSelector:
-  cloud.google.com/gke-nodepool: integration-node
+  cloud.google.com/gke-nodepool: integration-node-2

--- a/integration/integration-4/integration-4Deployment.yaml
+++ b/integration/integration-4/integration-4Deployment.yaml
@@ -15,7 +15,7 @@ gcloud-sqlproxy:
   networkPolicy:
     enabled: false
   nodeSelector:
-    cloud.google.com/gke-nodepool: integration-node
+    cloud.google.com/gke-nodepool: integration-node-2
 datarepo-api:
   enabled: true
   image:
@@ -43,7 +43,7 @@ datarepo-api:
   existingSecretSA: "jade-sa"
   existingServiceAccountSecretKey: "datareposerviceaccount"
   nodeSelector:
-    cloud.google.com/gke-nodepool: integration-node
+    cloud.google.com/gke-nodepool: integration-node-2
 datarepo-ui:
   enabled: true
   image:
@@ -58,7 +58,7 @@ datarepo-ui:
   rbac:
     create: true
   nodeSelector:
-    cloud.google.com/gke-nodepool: integration-node
+    cloud.google.com/gke-nodepool: integration-node-2
 oidc-proxy:
   replicaCount: 1
   enabled: true
@@ -90,4 +90,4 @@ oidc-proxy:
     create: true
     pspEnabled: true
   nodeSelector:
-    cloud.google.com/gke-nodepool: integration-node
+    cloud.google.com/gke-nodepool: integration-node-2

--- a/integration/integration-6/datarepo-api.yaml
+++ b/integration/integration-6/datarepo-api.yaml
@@ -22,4 +22,4 @@ existingStairwayDbSecretKey: "stairwaypassword"
 existingSecretSA: "jade-sa"
 existingServiceAccountSecretKey: "datareposerviceaccount"
 nodeSelector:
-  cloud.google.com/gke-nodepool: integration-node
+  cloud.google.com/gke-nodepool: integration-node-2

--- a/integration/integration-6/datarepo-ui.yaml
+++ b/integration/integration-6/datarepo-ui.yaml
@@ -11,4 +11,4 @@ serviceAccount:
 rbac:
   create: true
 nodeSelector:
-  cloud.google.com/gke-nodepool: integration-node
+  cloud.google.com/gke-nodepool: integration-node-2

--- a/integration/integration-6/gcloud-sqlproxy.yaml
+++ b/integration/integration-6/gcloud-sqlproxy.yaml
@@ -14,4 +14,4 @@ rbac:
 networkPolicy:
   enabled: false
 nodeSelector:
- cloud.google.com/gke-nodepool: integration-node
+ cloud.google.com/gke-nodepool: integration-node-2

--- a/integration/integration-6/integration-6Deployment.yaml
+++ b/integration/integration-6/integration-6Deployment.yaml
@@ -15,7 +15,7 @@ gcloud-sqlproxy:
   networkPolicy:
     enabled: false
   nodeSelector:
-    cloud.google.com/gke-nodepool: integration-node
+    cloud.google.com/gke-nodepool: integration-node-2
 datarepo-api:
   enabled: true
   image:
@@ -41,7 +41,7 @@ datarepo-api:
   existingSecretSA: "jade-sa"
   existingServiceAccountSecretKey: "datareposerviceaccount"
   nodeSelector:
-    cloud.google.com/gke-nodepool: integration-node
+    cloud.google.com/gke-nodepool: integration-node-2
 datarepo-ui:
   enabled: true
   image:
@@ -56,7 +56,7 @@ datarepo-ui:
   rbac:
     create: true
   nodeSelector:
-    cloud.google.com/gke-nodepool: integration-node
+    cloud.google.com/gke-nodepool: integration-node-2
 oidc-proxy:
   enabled: true
   replicaCount: 1
@@ -88,4 +88,4 @@ oidc-proxy:
     create: true
     pspEnabled: true
   nodeSelector:
-    cloud.google.com/gke-nodepool: integration-node
+    cloud.google.com/gke-nodepool: integration-node-2

--- a/integration/integration-6/oidc-proxy.yaml
+++ b/integration/integration-6/oidc-proxy.yaml
@@ -28,4 +28,4 @@ rbac:
   create: true
   pspEnabled: true
 nodeSelector:
-  cloud.google.com/gke-nodepool: integration-node
+  cloud.google.com/gke-nodepool: integration-node-2


### PR DESCRIPTION
Mark added new node pools to dev and int. This change, when deployed, will move the dev deployment to its own set of nodes and run 3 "api" pods (instances of DRmanager)

Since dev and int use the same terraform, integration also get a second node pool. So I adjusted the deployment of the _**even**_ numbered integration name spaces to use the second pool. Since integration tests allocate in sequence 1,2,3,6, it will remove node contention. It also splits the UI test environments across the node pools, FWIW.

This is all pretty short-term. At some point post-production, we will redefine and redeploy these environments.