### PR TITLE
DR-1382 - take 2: Use the right variable for replicas

### DIFF
--- a/dev/dev/devDeployment.yaml
+++ b/dev/dev/devDeployment.yaml
@@ -43,7 +43,7 @@ datarepo-api:
   existingServiceAccountSecretKey: "datareposerviceaccount"
   nodeSelector:
     cloud.google.com/gke-nodepool: dev-node-2
-  replicas: 3
+  replicaCount: 3
 datarepo-ui:
   enabled: true
   image:


### PR DESCRIPTION
I specified replicas using the kubernetes `replicas` name.
But the definition yaml uses a variable called `replicaCount`.
So let's try this way...
