### PR TITLE
Perf Datarepo version update: 3bedb0a

### DIFF
--- a/perf/datarepo-api.yaml
+++ b/perf/datarepo-api.yaml
@@ -1,5 +1,5 @@
 image:
-  tag: 70f3c91
+  tag: 3bedb0a
 env:
   GOOGLE_PROJECTID: broad-jade-perf
   GOOGLE_SINGLEDATAPROJECTID: broad-jade-perf-data2


### PR DESCRIPTION
Update versions in perf env to reflect image tag 3bedb0a.
*Note: This PR was opened by the [test-runner-perf GitHub Actions workflow](https://github.com/DataBiosphere/jade-data-repo/actions/runs/293927528).*