### PR TITLE
Perf Datarepo version update: 1.0.129

### DIFF
--- a/perf/datarepo-api.yaml
+++ b/perf/datarepo-api.yaml
@@ -1,5 +1,5 @@
 image:
-  tag: 5e62eee
+  tag: 1.0.129
 replicaCount: 3
 env:
   GOOGLE_PROJECTID: broad-jade-perf


### PR DESCRIPTION
Update versions in perf env to reflect image tag 1.0.129.
*Note: This PR was opened by the [test-runner-perf GitHub Actions workflow](https://github.com/DataBiosphere/jade-data-repo/actions/runs/306702886).*