### PR TITLE
Datarepo version update: 0.0.138

### DIFF
--- a/integration/integration-1/datarepo-ui.yaml
+++ b/integration/integration-1/datarepo-ui.yaml
@@ -1,5 +1,5 @@
 image:
-  tag: 0.0.137
+  tag: 0.0.138
 proxyPass:
   status: http://integration-1-jade-datarepo-api.integration-1:8080/status
   swagger: http://integration-1-jade-datarepo-api.integration-1:8080/swagger-ui.html

--- a/integration/integration-2/datarepo-ui.yaml
+++ b/integration/integration-2/datarepo-ui.yaml
@@ -1,5 +1,5 @@
 image:
-  tag: 0.0.137
+  tag: 0.0.138
 proxyPass:
   status: http://integration-2-jade-datarepo-api.integration-2:8080/status
   swagger: http://integration-2-jade-datarepo-api.integration-2:8080/swagger-ui.html

--- a/integration/integration-3/datarepo-ui.yaml
+++ b/integration/integration-3/datarepo-ui.yaml
@@ -1,5 +1,5 @@
 image:
-  tag: 0.0.137
+  tag: 0.0.138
 proxyPass:
   status: http://integration-3-jade-datarepo-api.integration-3:8080/status
   swagger: http://integration-3-jade-datarepo-api.integration-3:8080/swagger-ui.html

--- a/integration/integration-4/datarepo-ui.yaml
+++ b/integration/integration-4/datarepo-ui.yaml
@@ -1,5 +1,5 @@
 image:
-  tag: 0.0.137
+  tag: 0.0.138
 proxyPass:
   status: http://integration-4-jade-datarepo-api.integration-4:8080/status
   swagger: http://integration-4-jade-datarepo-api.integration-4:8080/swagger-ui.html

--- a/integration/integration-5/datarepo-ui.yaml
+++ b/integration/integration-5/datarepo-ui.yaml
@@ -1,5 +1,5 @@
 image:
-  tag: 0.0.137
+  tag: 0.0.138
 proxyPass:
   status: http://integration-5-jade-datarepo-api.integration-5:8080/status
   swagger: http://integration-5-jade-datarepo-api.integration-5:8080/swagger-ui.html

--- a/integration/integration-6/datarepo-ui.yaml
+++ b/integration/integration-6/datarepo-ui.yaml
@@ -1,5 +1,5 @@
 image:
-  tag: 0.0.137
+  tag: 0.0.138
 proxyPass:
   status: http://integration-6-jade-datarepo-api.integration-6:8080/status
   swagger: http://integration-6-jade-datarepo-api.integration-6:8080/swagger-ui.html


### PR DESCRIPTION
Update versions in **0.0.138**.
*Note: This PR was opened by the [update-env GitHub Actions workflow](https://github.com/DataBiosphere/jade-data-repo-ui/actions/runs/357433780).*