### PR TITLE
DR-1506 Add integration profile to perf so it uses proxy authentication

### DIFF
--- a/perf/datarepo/datarepo-api.yaml
+++ b/perf/datarepo/datarepo-api.yaml
@@ -5,7 +5,7 @@ env:
   GOOGLE_PROJECTID: broad-jade-perf
   GOOGLE_SINGLEDATAPROJECTID: broad-jade-perf-data2
   DB_DATAREPO_USERNAME: drmanager
-  SPRING_PROFILES_ACTIVE: google,cloudsql,perftest
+  SPRING_PROFILES_ACTIVE: google,cloudsql,perftest,integration
   DB_STAIRWAY_USERNAME: drmanager
   DB_STAIRWAY_URI: jdbc:postgresql://perf-jade-gcloud-sqlproxy.perf:5432/stairway
   DB_DATAREPO_URI: jdbc:postgresql://perf-jade-gcloud-sqlproxy.perf:5432/datarepo


### PR DESCRIPTION
This is a band-aid to get overnight TestRunner tests to work properly. I will make a ticket for a better fix.

Adding integration as a profile will make the perf deployment use the proxied authenticated user instead of local (i.e., jhert) fake user.

