### PR TITLE
Perf Datarepo version update: 1.0.175

### DIFF
--- a/perf/datarepo/datarepo-api.yaml
+++ b/perf/datarepo/datarepo-api.yaml
@@ -1,5 +1,5 @@
 image:
-  tag: 1.0.173
+  tag: 1.0.175
 replicaCount: 3
 env:
   GOOGLE_PROJECTID: broad-jade-perf


### PR DESCRIPTION
Update versions in perf env to reflect image tag 1.0.175.
*Note: This PR was opened by the [test-runner-perf GitHub Actions workflow](https://github.com/DataBiosphere/jade-data-repo/actions/runs/402041146).*