### PR TITLE
DR-1554: Update all datarepo-helm/oidc-proxy chart versions to current

### DIFF
--- a/dev/fb/helmfile.yaml
+++ b/dev/fb/helmfile.yaml
@@ -44,7 +44,7 @@ releases:
     namespace: fb   # target namespace
     createNamespace: true
     chart: datarepo-helm/oidc-proxy   # the chart name
-    version: 0.0.17    # chart version
+    version: 0.0.18    # chart version
     missingFileHandler: Warn
     values:
       - oidc-proxy.yaml   # Value files passed via --values

--- a/dev/mm/helmfile.yaml
+++ b/dev/mm/helmfile.yaml
@@ -44,7 +44,7 @@ releases:
     namespace: mm   # target namespace
     createNamespace: true
     chart: datarepo-helm/oidc-proxy   # the chart name
-    version: 0.0.9    # chart version
+    version: 0.0.18    # chart version
     missingFileHandler: Warn
     values:
       - oidc-proxy.yaml   # Value files passed via --values

--- a/dev/ms/helmfile.yaml
+++ b/dev/ms/helmfile.yaml
@@ -44,7 +44,7 @@ releases:
     namespace: ms   # target namespace
     createNamespace: true
     chart: datarepo-helm/oidc-proxy   # the chart name
-    version: 0.0.9    # chart version
+    version: 0.0.18    # chart version
     missingFileHandler: Warn
     values:
       - oidc-proxy.yaml   # Value files passed via --values

--- a/dev/nm/helmfile.yaml
+++ b/dev/nm/helmfile.yaml
@@ -44,7 +44,7 @@ releases:
     namespace: nm   # target namespace
     createNamespace: true
     chart: datarepo-helm/oidc-proxy   # the chart name
-    version: 0.0.14    # chart version
+    version: 0.0.18    # chart version
     missingFileHandler: Warn
     values:
       - oidc-proxy.yaml   # Value files passed via --values

--- a/dev/ps/helmfile.yaml
+++ b/dev/ps/helmfile.yaml
@@ -44,7 +44,7 @@ releases:
     namespace: ps   # target namespace
     createNamespace: true
     chart: datarepo-helm/oidc-proxy   # the chart name
-    version: 0.0.14    # chart version
+    version: 0.0.18    # chart version
     missingFileHandler: Warn
     values:
       - oidc-proxy.yaml   # Value files passed via --values

--- a/dev/rc/helmfile.yaml
+++ b/dev/rc/helmfile.yaml
@@ -44,7 +44,7 @@ releases:
     namespace: rc   # target namespace
     createNamespace: true
     chart: datarepo-helm/oidc-proxy   # the chart name
-    version: 0.0.15    # chart version
+    version: 0.0.18    # chart version
     missingFileHandler: Warn
     values:
       - oidc-proxy.yaml   # Value files passed via --values

--- a/dev/sh/helmfile.yaml
+++ b/dev/sh/helmfile.yaml
@@ -44,7 +44,7 @@ releases:
     namespace: sh   # target namespace
     createNamespace: true
     chart: datarepo-helm/oidc-proxy   # the chart name
-    version: 0.0.17    # chart version
+    version: 0.0.18    # chart version
     missingFileHandler: Warn
     values:
       - oidc-proxy.yaml   # Value files passed via --values

--- a/fakeprod/helmfile.yaml
+++ b/fakeprod/helmfile.yaml
@@ -36,7 +36,7 @@ releases:
     namespace: data-repo   # target namespace
     createNamespace: true
     chart: datarepo-helm/oidc-proxy   # the chart name
-    version: 0.0.14    # chart version
+    version: 0.0.18    # chart version
     missingFileHandler: Warn
     values:
       - oidc-proxy.yaml   # Value files passed via --values

--- a/integration/helmfile.yaml
+++ b/integration/helmfile.yaml
@@ -52,7 +52,7 @@ releases:
   - name: {{ .Environment.Name }}-jade-oidc-proxy   # name of this release
     namespace: {{ .Environment.Name }}   # target namespace
     chart: datarepo-helm/oidc-proxy   # the chart name
-    version: 0.0.14    # chart version
+    version: 0.0.18    # chart version
     missingFileHandler: Warn
     values:
       - {{ .Environment.Name }}/oidc-proxy.yaml   # Value files passed via --values

--- a/perf/helmfile.yaml
+++ b/perf/helmfile.yaml
@@ -42,7 +42,7 @@ releases:
   - name: perf-jade-oidc-proxy   # name of this release
     namespace: perf   # target namespace
     chart: datarepo-helm/oidc-proxy   # the chart name
-    version: 0.0.17    # chart version
+    version: 0.0.18    # chart version
     missingFileHandler: Warn
     values:
       - datarepo/oidc-proxy.yaml   # Value files passed via --values


### PR DESCRIPTION
This picks up the nosniff header change