### PR TITLE
added descheduler to all helmfiles for envs for hourly run

### DIFF
--- a/alpha/datarepomonitoring/datarepomonitoring.yaml
+++ b/alpha/datarepomonitoring/datarepomonitoring.yaml
@@ -37,7 +37,6 @@ kube-prometheus-stack:
       enabled: true
       annotations:
         kubernetes.io/ingress.global-static-ip-name: datarepo-prometheus-ip
-        networking.gke.io/v1beta1.FrontendConfig: global-ssl-policy
         kubernetes.io/ingress.allow-http: "false"
         networking.gke.io/managed-certificates: "prometheus-gcp-managed-cert"
       hosts:
@@ -102,6 +101,5 @@ kube-prometheus-stack:
         - datarepo-grafana.alpha.envs-terra.bio
       annotations:
         kubernetes.io/ingress.global-static-ip-name: datarepo-grafana-ip
-        networking.gke.io/v1beta1.FrontendConfig: global-ssl-policy
         kubernetes.io/ingress.allow-http: "false"
         networking.gke.io/managed-certificates: "grafana-gcp-managed-cert"

--- a/alpha/helmfile.yaml
+++ b/alpha/helmfile.yaml
@@ -2,12 +2,20 @@
 repositories:
   - name: datarepo-helm
     url: https://broadinstitute.github.io/datarepo-helm
+  - name: descheduler
+    url: https://kubernetes-sigs.github.io/descheduler
 
 helmDefaults:
   createNamespace: true
 
 # helm releases to be deployed
 releases:
+  - name: descheduler   # release name
+    namespace: kube-system   # target namespace
+    chart: descheduler/descheduler   # chart name
+    missingFileHandler: Warn
+    values:
+      - schedule: "0 * * * *"
   - name: datarepomonitoring   # release name
     namespace: monitoring   # target namespace
     chart: datarepo-helm/datarepomonitoring   # chart name

--- a/fakeprod/helmfile.yaml
+++ b/fakeprod/helmfile.yaml
@@ -3,11 +3,19 @@
 # helm plugin install https://github.com/databus23/helm-diff
 # repositories to be installed
 repositories:
+  - name: descheduler
+    url: https://kubernetes-sigs.github.io/descheduler
   - name: datarepo-helm
     url: https://broadinstitute.github.io/datarepo-helm
 
 # helm releases to be deployed
 releases:
+  - name: descheduler   # release name
+    namespace: kube-system   # target namespace
+    chart: descheduler/descheduler   # chart name
+    missingFileHandler: Warn
+    values:
+      - schedule: "0 * * * *"
   - name: terra-jade-gcloud-sqlproxy    # release name
     namespace: data-repo   # target namespace
     createNamespace: true

--- a/integration/helmfile.yaml
+++ b/integration/helmfile.yaml
@@ -5,6 +5,8 @@
 repositories:
   - name: datarepo-helm
     url: https://broadinstitute.github.io/datarepo-helm
+  - name: descheduler
+    url: https://kubernetes-sigs.github.io/descheduler
 
 helmDefaults:
   createNamespace: true
@@ -21,6 +23,12 @@ environments:
 ### Environment-specific resources
 {{- if ne .Environment.Name "default" }} # Only render these if an environment is given with -e
 releases:
+  - name: descheduler   # release name
+    namespace: kube-system   # target namespace
+    chart: descheduler/descheduler   # chart name
+    missingFileHandler: Warn
+    values:
+      - schedule: "0 * * * *"
   - name: {{ .Environment.Name }}-jade-create-secret-manager-secret    # release name
     namespace: {{ .Environment.Name }}   # target namespace
     chart: datarepo-helm/create-secret-manager-secret   # chart name

--- a/perf/helmfile.yaml
+++ b/perf/helmfile.yaml
@@ -5,12 +5,20 @@
 repositories:
   - name: datarepo-helm
     url: https://broadinstitute.github.io/datarepo-helm
+  - name: descheduler
+    url: https://kubernetes-sigs.github.io/descheduler
 
 helmDefaults:
   createNamespace: true
 
 # helm releases to be deployed
 releases:
+  - name: descheduler   # release name
+    namespace: kube-system   # target namespace
+    chart: descheduler/descheduler   # chart name
+    missingFileHandler: Warn
+    values:
+      - schedule: "0 * * * *"
   - name: perf-jade-create-secret-manager-secret    # release name
     namespace: perf   # target namespace
     chart: datarepo-helm/create-secret-manager-secret   # chart name

--- a/prod/datarepomonitoring/datarepomonitoring.yaml
+++ b/prod/datarepomonitoring/datarepomonitoring.yaml
@@ -37,7 +37,6 @@ kube-prometheus-stack:
       enabled: true
       annotations:
         kubernetes.io/ingress.global-static-ip-name: datarepo-prometheus-ip
-        networking.gke.io/v1beta1.FrontendConfig: global-ssl-policy
         kubernetes.io/ingress.allow-http: "false"
         networking.gke.io/managed-certificates: "prometheus-gcp-managed-cert"
       hosts:
@@ -103,6 +102,5 @@ kube-prometheus-stack:
         - datarepo-grafana.terra.bio
       annotations:
         kubernetes.io/ingress.global-static-ip-name: datarepo-grafana-ip
-        networking.gke.io/v1beta1.FrontendConfig: global-ssl-policy
         kubernetes.io/ingress.allow-http: "false"
         networking.gke.io/managed-certificates: "grafana-gcp-managed-cert"

--- a/prod/helmfile.yaml
+++ b/prod/helmfile.yaml
@@ -1,5 +1,7 @@
 ---
 repositories:
+  - name: descheduler
+    url: https://kubernetes-sigs.github.io/descheduler
   - name: datarepo-helm
     url: https://broadinstitute.github.io/datarepo-helm
 
@@ -8,6 +10,12 @@ helmDefaults:
 
 # helm releases to be deployed
 releases:
+  - name: descheduler   # release name
+    namespace: kube-system   # target namespace
+    chart: descheduler/descheduler   # chart name
+    missingFileHandler: Warn
+    values:
+      - schedule: "0 * * * *"
   - name: datarepomonitoring   # release name
     namespace: monitoring   # target namespace
     chart: datarepo-helm/datarepomonitoring   # chart name

--- a/staging/datarepomonitoring/datarepomonitoring.yaml
+++ b/staging/datarepomonitoring/datarepomonitoring.yaml
@@ -37,7 +37,6 @@ kube-prometheus-stack:
       enabled: true
       annotations:
         kubernetes.io/ingress.global-static-ip-name: datarepo-prometheus-ip
-        networking.gke.io/v1beta1.FrontendConfig: global-ssl-policy
         kubernetes.io/ingress.allow-http: "false"
         networking.gke.io/managed-certificates: "prometheus-gcp-managed-cert"
       hosts:
@@ -102,6 +101,5 @@ kube-prometheus-stack:
         - datarepo-grafana.staging.envs-terra.bio
       annotations:
         kubernetes.io/ingress.global-static-ip-name: datarepo-grafana-ip
-        networking.gke.io/v1beta1.FrontendConfig: global-ssl-policy
         kubernetes.io/ingress.allow-http: "false"
         networking.gke.io/managed-certificates: "grafana-gcp-managed-cert"

--- a/staging/helmfile.yaml
+++ b/staging/helmfile.yaml
@@ -4,12 +4,20 @@ repositories:
     url: https://kubernetes-sigs.github.io/descheduler
   - name: datarepo-helm
     url: https://broadinstitute.github.io/datarepo-helm
+  - name: descheduler
+    url: https://kubernetes-sigs.github.io/descheduler
 
 helmDefaults:
   createNamespace: true
 
 # helm releases to be deployed
 releases:
+  - name: descheduler   # release name
+    namespace: kube-system   # target namespace
+    chart: descheduler/descheduler   # chart name
+    missingFileHandler: Warn
+    values:
+      - schedule: "0 * * * *"
   - name: descheduler   # release name
     namespace: kube-system   # target namespace
     chart: descheduler/descheduler   # chart name

--- a/staging/helmfile.yaml
+++ b/staging/helmfile.yaml
@@ -4,20 +4,12 @@ repositories:
     url: https://kubernetes-sigs.github.io/descheduler
   - name: datarepo-helm
     url: https://broadinstitute.github.io/datarepo-helm
-  - name: descheduler
-    url: https://kubernetes-sigs.github.io/descheduler
 
 helmDefaults:
   createNamespace: true
 
 # helm releases to be deployed
 releases:
-  - name: descheduler   # release name
-    namespace: kube-system   # target namespace
-    chart: descheduler/descheduler   # chart name
-    missingFileHandler: Warn
-    values:
-      - schedule: "0 * * * *"
   - name: descheduler   # release name
     namespace: kube-system   # target namespace
     chart: descheduler/descheduler   # chart name

--- a/staging/helmfile.yaml
+++ b/staging/helmfile.yaml
@@ -1,5 +1,7 @@
 ---
 repositories:
+  - name: descheduler
+    url: https://kubernetes-sigs.github.io/descheduler
   - name: datarepo-helm
     url: https://broadinstitute.github.io/datarepo-helm
 
@@ -8,6 +10,12 @@ helmDefaults:
 
 # helm releases to be deployed
 releases:
+  - name: descheduler   # release name
+    namespace: kube-system   # target namespace
+    chart: descheduler/descheduler   # chart name
+    missingFileHandler: Warn
+    values:
+      - schedule: "0 * * * *"
   - name: datarepomonitoring   # release name
     namespace: monitoring   # target namespace
     chart: datarepo-helm/datarepomonitoring   # chart name


### PR DESCRIPTION
Kube scheduler is piling up resources on certain node and since they are not being recreated they cannot move this reoccurring job would move pods around hourly balancing them across nodes. 

Alpha alert today: https://console.cloud.google.com/monitoring/alerting/policies/9870185772218155901?project=terra-datarepo-alpha