### PR TITLE
Datarepo version update: 1.31.0

### DIFF
--- a/integration/integration-1/datarepo-api.yaml
+++ b/integration/integration-1/datarepo-api.yaml
@@ -1,5 +1,5 @@
 image:
-  tag: 1.30.0
+  tag: 1.31.0
 env:
   GOOGLE_PROJECTID: broad-jade-integration
   GOOGLE_SINGLEDATAPROJECTID: broad-jade-int-1-data

--- a/integration/integration-2/datarepo-api.yaml
+++ b/integration/integration-2/datarepo-api.yaml
@@ -1,5 +1,5 @@
 image:
-  tag: 1.30.0
+  tag: 1.31.0
 env:
   GOOGLE_PROJECTID: broad-jade-integration
   GOOGLE_SINGLEDATAPROJECTID: broad-jade-int-2-data

--- a/integration/integration-3/datarepo-api.yaml
+++ b/integration/integration-3/datarepo-api.yaml
@@ -1,5 +1,5 @@
 image:
-  tag: 1.30.0
+  tag: 1.31.0
 env:
   GOOGLE_PROJECTID: broad-jade-integration
   GOOGLE_SINGLEDATAPROJECTID: broad-jade-int-3-data

--- a/integration/integration-4/datarepo-api.yaml
+++ b/integration/integration-4/datarepo-api.yaml
@@ -1,5 +1,5 @@
 image:
-  tag: 1.30.0
+  tag: 1.31.0
 env:
   GOOGLE_PROJECTID: broad-jade-integration
   GOOGLE_SINGLEDATAPROJECTID: broad-jade-int-4-data

--- a/integration/integration-5/datarepo-api.yaml
+++ b/integration/integration-5/datarepo-api.yaml
@@ -1,5 +1,5 @@
 image:
-  tag: 1.30.0
+  tag: 1.31.0
 env:
   GOOGLE_PROJECTID: broad-jade-integration
   GOOGLE_SINGLEDATAPROJECTID: broad-jade-int-5-data

--- a/integration/integration-6/datarepo-api.yaml
+++ b/integration/integration-6/datarepo-api.yaml
@@ -1,5 +1,5 @@
 image:
-  tag: 1.30.0
+  tag: 1.31.0
 env:
   GOOGLE_PROJECTID: broad-jade-integration
   GOOGLE_SINGLEDATAPROJECTID: broad-jade-int-6-data


### PR DESCRIPTION
Update versions in **1.31.0**.
*Note: This PR was opened by the [update-env GitHub Actions workflow](https://github.com/DataBiosphere/jade-data-repo/actions/runs/594765260).*