### PR TITLE
[DR-1632] Add grafana dashboard with JVM metrics

### DIFF
--- a/alpha/datarepomonitoring/kube-prometheus-stack.yaml
+++ b/alpha/datarepomonitoring/kube-prometheus-stack.yaml
@@ -72,7 +72,7 @@ grafana:
   dashboards:
     default:
       jvm-dashboard:
-        url: https://raw.githubusercontent.com/broadinstitute/datarepo-helm-definitions/add-grafana-dashboard/perf/datarepomonitoring/dashboards/prometheus-metrics.json
+        url: https://raw.githubusercontent.com/broadinstitute/datarepo-helm-definitions/master/dashboards/jvm-dashboard.json
   rbac:
     create: true
     pspEnabled: true

--- a/dashboards/jvm-dashboard.json
+++ b/dashboards/jvm-dashboard.json
@@ -1,0 +1,201 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "datasource": "Prometheus",
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "mappings": [],
+          "max": 100,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "#EAB839",
+                "value": 80
+              },
+              {
+                "color": "red",
+                "value": 90
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
+      "id": 4,
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "mean"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true
+      },
+      "pluginVersion": "7.2.0",
+      "targets": [
+        {
+          "expr": "sum(jvm_memory_used_bytes)/sum(jvm_memory_max_bytes) * 100",
+          "interval": "",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "JVM Percent Memory Usage",
+      "type": "gauge"
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "Prometheus",
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 8
+      },
+      "hiddenSeries": false,
+      "id": 2,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.2.0",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "sum(jvm_memory_used_bytes)",
+          "interval": "",
+          "legendFormat": "jvm_memory_used_bytes",
+          "refId": "A"
+        },
+        {
+          "expr": "sum(jvm_memory_max_bytes)",
+          "interval": "",
+          "legendFormat": "jvm_memory_max_bytes",
+          "refId": "B"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "JVM Total Memory Usage",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "decbytes",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    }
+  ],
+  "schemaVersion": 26,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "Prometheus / Metrics",
+  "uid": null,
+  "version": 0
+}

--- a/dev/monitoring/kube-prometheus-stack.yaml
+++ b/dev/monitoring/kube-prometheus-stack.yaml
@@ -58,7 +58,7 @@ grafana:
   dashboards:
     default:
       jvm-dashboard:
-        url: https://raw.githubusercontent.com/broadinstitute/datarepo-helm-definitions/se-add-grafana-dashboards/dashboards/jvm-dashboard.json
+        url: https://raw.githubusercontent.com/broadinstitute/datarepo-helm-definitions/master/dashboards/jvm-dashboard.json
   rbac:
     create: true
     pspEnabled: true

--- a/dev/monitoring/kube-prometheus-stack.yaml
+++ b/dev/monitoring/kube-prometheus-stack.yaml
@@ -58,7 +58,7 @@ grafana:
   dashboards:
     default:
       jvm-dashboard:
-        url: https://raw.githubusercontent.com/broadinstitute/datarepo-helm-definitions/add-grafana-dashboard/perf/datarepomonitoring/dashboards/prometheus-metrics.json
+        url: https://raw.githubusercontent.com/broadinstitute/datarepo-helm-definitions/se-add-grafana-dashboards/dashboards/jvm-dashboard.json
   rbac:
     create: true
     pspEnabled: true

--- a/dev/monitoring/kube-prometheus-stack.yaml
+++ b/dev/monitoring/kube-prometheus-stack.yaml
@@ -43,6 +43,22 @@ prometheus:
           - name: prometheus-datarepo-monitoring-kube-p-prometheus-db       #  in deployment yaml changes with helm deploy
             mountPath: /prometheus
 grafana:
+  dashboardProviders:
+    dashboardproviders.yaml:
+      apiVersion: 1
+      providers:
+        - name: 'default'
+          orgId: 1
+          folder: ''
+          type: file
+          disableDeletion: false
+          editable: true
+          options:
+            path: /var/lib/grafana/dashboards/default
+  dashboards:
+    default:
+      jvm-dashboard:
+        url: https://raw.githubusercontent.com/broadinstitute/datarepo-helm-definitions/add-grafana-dashboard/perf/datarepomonitoring/dashboards/prometheus-metrics.json
   rbac:
     create: true
     pspEnabled: true
@@ -76,26 +92,3 @@ grafana:
       kubernetes.io/ingress.global-static-ip-name: grafana-k8-100
       kubernetes.io/ingress.allow-http: "false"
       networking.gke.io/managed-certificates: "grafana-gcp-managed-cert"
-  dashboardProviders:
-    dashboardproviders.yaml:
-      apiVersion: 1
-      providers:
-      - name: 'default'
-        orgId: 1
-        folder: ''
-        type: file
-        disableDeletion: false
-        editable: true
-        options:
-          path: /var/lib/grafana/dashboards/default
-  dashboards:
-    default:
-      local-dashboard:
-        url: https://raw.githubusercontent.com/broadinstitute/datarepo-helm-definitions/add-grafana-dashboard/perf/datarepomonitoring/dashboards/prometheus-metrics.json
-  datasources:
-    datasources.yaml:
-      apiVersion: 1
-      datasources:
-        - name: Prometheus
-          type: prometheus
-          url: http://datarepomonitoring-kube-pr-prometheus:9090

--- a/dev/monitoring/kube-prometheus-stack.yaml
+++ b/dev/monitoring/kube-prometheus-stack.yaml
@@ -76,3 +76,26 @@ grafana:
       kubernetes.io/ingress.global-static-ip-name: grafana-k8-100
       kubernetes.io/ingress.allow-http: "false"
       networking.gke.io/managed-certificates: "grafana-gcp-managed-cert"
+  dashboardProviders:
+    dashboardproviders.yaml:
+      apiVersion: 1
+      providers:
+      - name: 'default'
+        orgId: 1
+        folder: ''
+        type: file
+        disableDeletion: false
+        editable: true
+        options:
+          path: /var/lib/grafana/dashboards/default
+  dashboards:
+    default:
+      local-dashboard:
+        url: https://raw.githubusercontent.com/broadinstitute/datarepo-helm-definitions/add-grafana-dashboard/perf/datarepomonitoring/dashboards/prometheus-metrics.json
+  datasources:
+    datasources.yaml:
+      apiVersion: 1
+      datasources:
+        - name: Prometheus
+          type: prometheus
+          url: http://datarepomonitoring-kube-pr-prometheus:9090

--- a/perf/datarepomonitoring/kube-prometheus-stack.yaml
+++ b/perf/datarepomonitoring/kube-prometheus-stack.yaml
@@ -72,7 +72,7 @@ grafana:
   dashboards:
     default:
       jvm-dashboard:
-        url: https://raw.githubusercontent.com/broadinstitute/datarepo-helm-definitions/add-grafana-dashboard/perf/datarepomonitoring/dashboards/prometheus-metrics.json
+        url: https://raw.githubusercontent.com/broadinstitute/datarepo-helm-definitions/master/dashboards/jvm-dashboard.json
   rbac:
     create: true
     pspEnabled: true

--- a/prod/datarepomonitoring/kube-prometheus-stack.yaml
+++ b/prod/datarepomonitoring/kube-prometheus-stack.yaml
@@ -58,6 +58,22 @@ prometheus:
           - name: prometheus-datarepomonitoring-kube-pr-prometheus-db       #  in deployment yaml changes with helm deploy
             mountPath: /prometheus
 grafana:
+  dashboardProviders:
+    dashboardproviders.yaml:
+      apiVersion: 1
+      providers:
+        - name: 'default'
+          orgId: 1
+          folder: ''
+          type: file
+          disableDeletion: false
+          editable: true
+          options:
+            path: /var/lib/grafana/dashboards/default
+  dashboards:
+    default:
+      jvm-dashboard:
+        url: https://raw.githubusercontent.com/broadinstitute/datarepo-helm-definitions/master/dashboards/jvm-dashboard.json
   rbac:
     create: true
     pspEnabled: true

--- a/staging/datarepomonitoring/kube-prometheus-stack.yaml
+++ b/staging/datarepomonitoring/kube-prometheus-stack.yaml
@@ -57,6 +57,22 @@ prometheus:
           - name: prometheus-datarepomonitoring-kube-pr-prometheus-db       #  in deployment yaml changes with helm deploy
             mountPath: /prometheus
 grafana:
+  dashboardProviders:
+    dashboardproviders.yaml:
+      apiVersion: 1
+      providers:
+        - name: 'default'
+          orgId: 1
+          folder: ''
+          type: file
+          disableDeletion: false
+          editable: true
+          options:
+            path: /var/lib/grafana/dashboards/default
+  dashboards:
+    default:
+      jvm-dashboard:
+        url: https://raw.githubusercontent.com/broadinstitute/datarepo-helm-definitions/master/dashboards/jvm-dashboard.json
   rbac:
     create: true
     pspEnabled: true


### PR DESCRIPTION
Link to dev dashboard (requires VPN): https://grafana.datarepo-dev.broadinstitute.org/d/oUibWbsGz/prometheus-metrics?orgId=1&from=1614341360202&to=1614342704333
