### PR TITLE
[DR-1658] Update oidc-proxy values

### DIFF
--- a/dev/dev/devDeployment.yaml
+++ b/dev/dev/devDeployment.yaml
@@ -61,7 +61,8 @@ oidc-proxy:
   env:
     PROXY_URL: http://dev-jade-datarepo-ui.dev:8080/
     PROXY_URL2: http://dev-jade-datarepo-api.dev:8080/api
-    PROXY_URL3: http://dev-jade-datarepo-api.dev:8080/register
+    PROXY_URL3: http://se-jade-datarepo-api.se:8080/ga4gh
+    PROXY_PATH3: /ga4gh
     LOG_LEVEL: debug
     SERVER_NAME: jade.datarepo-dev.broadinstitute.org
     REMOTE_USER_CLAIM: sub

--- a/dev/se/helmfile.yaml
+++ b/dev/se/helmfile.yaml
@@ -44,7 +44,7 @@ releases:
     namespace: se   # target namespace
     createNamespace: true
     chart: datarepo-helm/oidc-proxy   # the chart name
-    version: 0.0.18    # chart version
+    version: 0.0.20    # chart version
     missingFileHandler: Warn
     values:
       - oidc-proxy.yaml   # Value files passed via --values

--- a/dev/se/oidc-proxy.yaml
+++ b/dev/se/oidc-proxy.yaml
@@ -2,7 +2,8 @@
 env:
   PROXY_URL: http://se-jade-datarepo-ui.se:8080/
   PROXY_URL2: http://se-jade-datarepo-api.se:8080/api
-  PROXY_URL3: http://se-jade-datarepo-api.se:8080/register
+  PROXY_URL3: http://se-jade-datarepo-api.se:8080/ga4gh
+  PROXY_PATH3: /ga4gh
   LOG_LEVEL: debug
   SERVER_NAME: jade.datarepo-dev.broadinstitute.org
   REMOTE_USER_CLAIM: sub
@@ -14,7 +15,7 @@ ingress:
   domainName: jade-se.datarepo-dev.broadinstitute.org
   annotations:
     kubernetes.io/ingress.global-static-ip-name: jade-dev-se
-    networking.gke.io/v1beta1.FrontendConfig: sh-jade-oidc-proxy
+    networking.gke.io/v1beta1.FrontendConfig: se-jade-oidc-proxy
   paths:
     - /*
   hosts:

--- a/fakeprod/helmfile.yaml
+++ b/fakeprod/helmfile.yaml
@@ -44,7 +44,7 @@ releases:
     namespace: data-repo   # target namespace
     createNamespace: true
     chart: datarepo-helm/oidc-proxy   # the chart name
-    version: 0.0.19    # chart version
+    version: 0.0.20    # chart version
     missingFileHandler: Warn
     values:
       - oidc-proxy.yaml   # Value files passed via --values

--- a/fakeprod/oidc-proxy.yaml
+++ b/fakeprod/oidc-proxy.yaml
@@ -2,7 +2,8 @@
 env:
   PROXY_URL: http://terra-jade-datarepo-ui.data-repo:8080/
   PROXY_URL2: http://terra-jade-datarepo-api.data-repo:8080/api
-  PROXY_URL3: http://terra-jade-datarepo-api.data-repo:8080/register
+  PROXY_URL3: http://se-jade-datarepo-api.se:8080/ga4gh
+  PROXY_PATH3: /ga4gh
   LOG_LEVEL: debug
   SERVER_NAME: jade-terra.datarepo-prod.broadinstitute.org
   REMOTE_USER_CLAIM: sub

--- a/integration/helmfile.yaml
+++ b/integration/helmfile.yaml
@@ -60,7 +60,7 @@ releases:
   - name: {{ .Environment.Name }}-jade-oidc-proxy   # name of this release
     namespace: {{ .Environment.Name }}   # target namespace
     chart: datarepo-helm/oidc-proxy   # the chart name
-    version: 0.0.14    # chart version
+    version: 0.0.20    # chart version
     missingFileHandler: Warn
     values:
       - {{ .Environment.Name }}/oidc-proxy.yaml   # Value files passed via --values

--- a/integration/integration-1/oidc-proxy.yaml
+++ b/integration/integration-1/oidc-proxy.yaml
@@ -3,7 +3,8 @@ replicaCount: 1
 env:
   PROXY_URL: http://integration-1-jade-datarepo-ui.integration-1:8080/
   PROXY_URL2: http://integration-1-jade-datarepo-api.integration-1:8080/api
-  PROXY_URL3: http://integration-1-jade-datarepo-api.integration-1:8080/register
+  PROXY_URL3: http://se-jade-datarepo-api.se:8080/ga4gh
+  PROXY_PATH3: /ga4gh
   LOG_LEVEL: debug
   SERVER_NAME: jade.datarepo-integration.broadinstitute.org
   REMOTE_USER_CLAIM: sub

--- a/integration/integration-2/oidc-proxy.yaml
+++ b/integration/integration-2/oidc-proxy.yaml
@@ -3,7 +3,8 @@ replicaCount: 1
 env:
   PROXY_URL: http://integration-2-jade-datarepo-ui.integration-2:8080/
   PROXY_URL2: http://integration-2-jade-datarepo-api.integration-2:8080/api
-  PROXY_URL3: http://integration-2-jade-datarepo-api.integration-2:8080/register
+  PROXY_URL3: http://se-jade-datarepo-api.se:8080/ga4gh
+  PROXY_PATH3: /ga4gh
   LOG_LEVEL: debug
   SERVER_NAME: jade.datarepo-integration.broadinstitute.org
   REMOTE_USER_CLAIM: sub

--- a/integration/integration-3/oidc-proxy.yaml
+++ b/integration/integration-3/oidc-proxy.yaml
@@ -3,7 +3,8 @@ replicaCount: 1
 env:
   PROXY_URL: http://integration-3-jade-datarepo-ui.integration-3:8080/
   PROXY_URL2: http://integration-3-jade-datarepo-api.integration-3:8080/api
-  PROXY_URL3: http://integration-3-jade-datarepo-api.integration-3:8080/register
+  PROXY_URL3: http://se-jade-datarepo-api.se:8080/ga4gh
+  PROXY_PATH3: /ga4gh
   LOG_LEVEL: debug
   SERVER_NAME: jade.datarepo-integration.broadinstitute.org
   REMOTE_USER_CLAIM: sub

--- a/integration/integration-4/oidc-proxy.yaml
+++ b/integration/integration-4/oidc-proxy.yaml
@@ -3,7 +3,8 @@ replicaCount: 1
 env:
   PROXY_URL: http://integration-4-jade-datarepo-ui.integration-4:8080/
   PROXY_URL2: http://integration-4-jade-datarepo-api.integration-4:8080/api
-  PROXY_URL3: http://integration-4-jade-datarepo-api.integration-4:8080/register
+  PROXY_URL3: http://se-jade-datarepo-api.se:8080/ga4gh
+  PROXY_PATH3: /ga4gh
   LOG_LEVEL: debug
   SERVER_NAME: jade.datarepo-integration.broadinstitute.org
   REMOTE_USER_CLAIM: sub

--- a/integration/integration-5/oidc-proxy.yaml
+++ b/integration/integration-5/oidc-proxy.yaml
@@ -3,7 +3,8 @@ replicaCount: 1
 env:
   PROXY_URL: http://integration-5-jade-datarepo-ui.integration-5:8080/
   PROXY_URL2: http://integration-5-jade-datarepo-api.integration-5:8080/api
-  PROXY_URL3: http://integration-5-jade-datarepo-api.integration-5:8080/register
+  PROXY_URL3: http://se-jade-datarepo-api.se:8080/ga4gh
+  PROXY_PATH3: /ga4gh
   LOG_LEVEL: debug
   SERVER_NAME: jade.datarepo-integration.broadinstitute.org
   REMOTE_USER_CLAIM: sub

--- a/integration/integration-6/oidc-proxy.yaml
+++ b/integration/integration-6/oidc-proxy.yaml
@@ -3,7 +3,8 @@ replicaCount: 1
 env:
   PROXY_URL: http://integration-6-jade-datarepo-ui.integration-6:8080/
   PROXY_URL2: http://integration-6-jade-datarepo-api.integration-6:8080/api
-  PROXY_URL3: http://integration-6-jade-datarepo-api.integration-6:8080/register
+  PROXY_URL3: http://se-jade-datarepo-api.se:8080/ga4gh
+  PROXY_PATH3: /ga4gh
   LOG_LEVEL: debug
   SERVER_NAME: jade.datarepo-integration.broadinstitute.org
   REMOTE_USER_CLAIM: sub

--- a/integration/integration-temp/oidc-proxy.yaml
+++ b/integration/integration-temp/oidc-proxy.yaml
@@ -3,7 +3,8 @@ enabled: true
 env:
   PROXY_URL: http://integration-temp-jade-datarepo-ui.integration-temp:8080/
   PROXY_URL2: http://integration-temp-jade-datarepo-api.integration-temp:8080/api
-  PROXY_URL3: http://integration-temp-jade-datarepo-api.integration-temp:8080/register
+  PROXY_URL3: http://se-jade-datarepo-api.se:8080/ga4gh
+  PROXY_PATH3: /ga4gh
   LOG_LEVEL: debug
   SERVER_NAME: jade.datarepo-integration.broadinstitute.org
   REMOTE_USER_CLAIM: sub

--- a/perf/datarepo/oidc-proxy.yaml
+++ b/perf/datarepo/oidc-proxy.yaml
@@ -3,7 +3,8 @@ replicaCount: 1
 env:
   PROXY_URL: http://perf-jade-datarepo-ui.perf:8080/
   PROXY_URL2: http://perf-jade-datarepo-api.perf:8080/api
-  PROXY_URL3: http://perf-jade-datarepo-api.perf:8080/register
+  PROXY_URL3: http://se-jade-datarepo-api.se:8080/ga4gh
+  PROXY_PATH3: /ga4gh
   LOG_LEVEL: debug
   SERVER_NAME: jade.datarepo-perf.broadinstitute.org
   REMOTE_USER_CLAIM: sub

--- a/perf/helmfile.yaml
+++ b/perf/helmfile.yaml
@@ -53,7 +53,7 @@ releases:
   - name: perf-jade-oidc-proxy   # name of this release
     namespace: perf   # target namespace
     chart: datarepo-helm/oidc-proxy   # the chart name
-    version: 0.0.18    # chart version
+    version: 0.0.20    # chart version
     missingFileHandler: Warn
     values:
       - datarepo/oidc-proxy.yaml   # Value files passed via --values


### PR DESCRIPTION
I updated the values for the oidc-proxy helm chart (updated in https://github.com/broadinstitute/datarepo-helm/pull/137) and deployed it to my personal dev instance to confirm that I see my user information in the logs.

This also updates perf, integration and fakeprod. Should I include the other developer environments under dev as well?