### PR TITLE
DR-1880 Pin the version of descheduler that we use

### DIFF
--- a/alpha/helmfile.yaml
+++ b/alpha/helmfile.yaml
@@ -17,6 +17,7 @@ releases:
   - name: descheduler   # release name
     namespace: kube-system   # target namespace
     chart: descheduler/descheduler   # chart name
+    version: v0.20.0 # chart version (note more recent charts break)
     missingFileHandler: Warn
     values:
       - schedule: "0 * * * *"

--- a/dev/descheduler/helmfile.yaml
+++ b/dev/descheduler/helmfile.yaml
@@ -8,6 +8,7 @@ releases:
   - name: descheduler   # release name
     namespace: kube-system   # target namespace
     chart: descheduler/descheduler   # chart name
+    version: v0.20.0 # chart version (note more recent charts break)
     missingFileHandler: Warn
     values:
       - schedule: "0 * * * *"

--- a/fakeprod/helmfile.yaml
+++ b/fakeprod/helmfile.yaml
@@ -13,6 +13,7 @@ releases:
   - name: descheduler   # release name
     namespace: kube-system   # target namespace
     chart: descheduler/descheduler   # chart name
+    version: v0.20.0 # chart version (note more recent charts break)
     missingFileHandler: Warn
     values:
       - schedule: "0 * * * *"

--- a/integration/helmfile.yaml
+++ b/integration/helmfile.yaml
@@ -26,6 +26,7 @@ releases:
   - name: descheduler   # release name
     namespace: kube-system   # target namespace
     chart: descheduler/descheduler   # chart name
+    version: v0.20.0 # chart version (note more recent charts break)
     missingFileHandler: Warn
     values:
       - schedule: "0 * * * *"

--- a/perf/helmfile.yaml
+++ b/perf/helmfile.yaml
@@ -16,6 +16,7 @@ releases:
   - name: descheduler   # release name
     namespace: kube-system   # target namespace
     chart: descheduler/descheduler   # chart name
+    version: v0.20.0 # chart version (note more recent charts break)
     missingFileHandler: Warn
     values:
       - schedule: "0 * * * *"

--- a/prod/helmfile.yaml
+++ b/prod/helmfile.yaml
@@ -17,6 +17,7 @@ releases:
   - name: descheduler   # release name
     namespace: kube-system   # target namespace
     chart: descheduler/descheduler   # chart name
+    version: v0.20.0 # chart version (note more recent charts break)
     missingFileHandler: Warn
     values:
       - schedule: "0 * * * *"

--- a/staging/helmfile.yaml
+++ b/staging/helmfile.yaml
@@ -17,6 +17,7 @@ releases:
   - name: descheduler   # release name
     namespace: kube-system   # target namespace
     chart: descheduler/descheduler   # chart name
+    version: v0.20.0 # chart version (note more recent charts break)
     missingFileHandler: Warn
     values:
       - schedule: "0 * * * *"


### PR DESCRIPTION
The new version doesn't appear to be compatible with our k8s cluster version