### PR TITLE
DR-1950 Bump fake prod and add RBS/Azure information to config

### DIFF
--- a/fakeprod/datarepo-api.yaml
+++ b/fakeprod/datarepo-api.yaml
@@ -3,6 +3,7 @@ replicaCount: 3
 env:
   GOOGLE_PROJECTID: broad-datarepo-terra-prod
   GOOGLE_FIRESTORERETRIES: 12
+  GOOGLE_DATAPROJECTPREFIX: tdr-prd1
   DB_DATAREPO_USERNAME: drmanager
   SPRING_PROFILES_ACTIVE: google,cloudsql,terra,prod
   DB_STAIRWAY_USERNAME: drmanager

--- a/fakeprod/datarepo-api.yaml
+++ b/fakeprod/datarepo-api.yaml
@@ -17,6 +17,11 @@ env:
   SAM_ADMINSGROUPEMAIL: DataRepoAdmins@firecloud.org
   OAUTH_CLIENTID: 92683655072-votlvbrvlkdnl32mqr01n7u4m0u4ku7n.apps.googleusercontent.com
   DATAREPO_LOADCONCURRENTFILES: 40
+  AZURE_CREDENTIALS_APPLICATIONID: 22cb243c-f1a5-43d8-8f12-6566bcce6542
+  AZURE_CREDENTIALS_HOMETENANTID: fad90753-2022-4456-9b0a-c7e5b934e408
+  RBS_ENABLED: false
+  RBS_POOL_ID: datarepo_v1
+  RBS_INSTANCE_URL: https://buffer.dsde-prod.broadinstitute.org
 serviceAccount:
   create: true
 rbac:
@@ -25,10 +30,9 @@ rbac:
 existingSecretDB: "api-secrets"
 existingDatarepoDbSecretKey: "datarepo-password"
 existingStairwayDbSecretKey: "stairway-password"
+existingSecretAzure: "api-secrets"
+existingApplicationSecretSecretKey: "application-secret"
 existingSecretSA: "sa-key"
 existingServiceAccountSecretKey: "credential-file-json"
-resources:
-  limits:
-    memory: 2560Mi
-  requests:
-    memory: 2048Mi
+existingSecretRBS: "rbs-sa-key"
+existingRBSSecretKey: "credential-file-json"

--- a/fakeprod/helmfile.yaml
+++ b/fakeprod/helmfile.yaml
@@ -29,7 +29,7 @@ releases:
     namespace: data-repo   # target namespace
     createNamespace: true
     chart: datarepo-helm/datarepo-api   # the chart name
-    version: 0.0.67    # chart version
+    version: 0.0.140    # chart version
     missingFileHandler: Warn
     values:
       - datarepo-api.yaml   # Value files passed via --values
@@ -37,7 +37,7 @@ releases:
     namespace: data-repo   # target namespace
     createNamespace: true
     chart: datarepo-helm/datarepo-ui   # the chart name
-    version: 0.0.61    # chart version
+    version: 0.0.78    # chart version
     missingFileHandler: Warn
     values:
       - datarepo-ui.yaml   # Value files passed via --values


### PR DESCRIPTION
Also, remove the memory overrides.

Note: I added the RBS service account and azure secret into the k8s secrets directly because fake prod is not setup to use our secret copier.  Not worth fixing at this point since this is literally just the deprecated HCA env until they move to the real prod instance