### PR TITLE
DR-2295 disable cloud trace logging

### DIFF
--- a/dev/az/datarepo-api.yaml
+++ b/dev/az/datarepo-api.yaml
@@ -15,6 +15,8 @@ env:
   RBS_ENABLED: true
   RBS_POOL_ID: datarepo_v1
   RBS_INSTANCE_URL: https://buffer.tools.integ.envs.broadinstitute.org
+  TERRA_COMMON_TRACING_STACKDRIVER_EXPORT_ENABLED: false
+  OPENCENCUS_SPRING_ENABLED: false
 serviceAccount:
   create: true
 rbac:

--- a/dev/dd/datarepo-api.yaml
+++ b/dev/dd/datarepo-api.yaml
@@ -18,6 +18,8 @@ env:
   RBS_ENABLED: true
   RBS_POOL_ID: datarepo_v3
   RBS_INSTANCE_URL: https://buffer.dsde-dev.broadinstitute.org
+  TERRA_COMMON_TRACING_STACKDRIVER_EXPORT_ENABLED: false
+  OPENCENCUS_SPRING_ENABLED: false
 serviceAccount:
   create: true
 rbac:

--- a/dev/dev/devDeployment.yaml
+++ b/dev/dev/devDeployment.yaml
@@ -39,6 +39,7 @@ datarepo-api:
     RBS_ENABLED: true
     RBS_POOL_ID: datarepo_v3
     RBS_INSTANCE_URL: https://buffer.dsde-dev.broadinstitute.org
+    TERRA_COMMON_TRACING_STACKDRIVER_EXPORT_ENABLED: false
   serviceAccount:
     create: true
   rbac:

--- a/dev/dev/devDeployment.yaml
+++ b/dev/dev/devDeployment.yaml
@@ -40,6 +40,7 @@ datarepo-api:
     RBS_POOL_ID: datarepo_v3
     RBS_INSTANCE_URL: https://buffer.dsde-dev.broadinstitute.org
     TERRA_COMMON_TRACING_STACKDRIVER_EXPORT_ENABLED: false
+    OPENCENCUS_SPRING_ENABLED: false
   serviceAccount:
     create: true
   rbac:

--- a/dev/fb/datarepo-api.yaml
+++ b/dev/fb/datarepo-api.yaml
@@ -17,6 +17,8 @@ env:
   RBS_ENABLED: true
   RBS_POOL_ID: datarepo_v3
   RBS_INSTANCE_URL: https://buffer.dsde-dev.broadinstitute.org
+  TERRA_COMMON_TRACING_STACKDRIVER_EXPORT_ENABLED: false
+  OPENCENCUS_SPRING_ENABLED: false
 serviceAccount:
   create: true
 rbac:

--- a/dev/my/datarepo-api.yaml
+++ b/dev/my/datarepo-api.yaml
@@ -16,6 +16,8 @@ env:
   RBS_ENABLED: true
   RBS_POOL_ID: datarepo_v3
   RBS_INSTANCE_URL: https://buffer.dsde-dev.broadinstitute.org
+  TERRA_COMMON_TRACING_STACKDRIVER_EXPORT_ENABLED: false
+  OPENCENCUS_SPRING_ENABLED: false
 serviceAccount:
   create: true
 rbac:

--- a/dev/nm/datarepo-api.yaml
+++ b/dev/nm/datarepo-api.yaml
@@ -18,6 +18,8 @@ env:
   RBS_ENABLED: true
   RBS_POOL_ID: datarepo_v3
   RBS_INSTANCE_URL: https://buffer.dsde-dev.broadinstitute.org
+  TERRA_COMMON_TRACING_STACKDRIVER_EXPORT_ENABLED: false
+  OPENCENCUS_SPRING_ENABLED: false
 serviceAccount:
   create: true
 rbac:

--- a/dev/ps/datarepo-api.yaml
+++ b/dev/ps/datarepo-api.yaml
@@ -18,6 +18,8 @@ env:
   RBS_ENABLED: true
   RBS_POOL_ID: datarepo_v3
   RBS_INSTANCE_URL: https://buffer.dsde-dev.broadinstitute.org
+  TERRA_COMMON_TRACING_STACKDRIVER_EXPORT_ENABLED: false
+  OPENCENCUS_SPRING_ENABLED: false
 serviceAccount:
   create: true
 rbac:

--- a/dev/rc/datarepo-api.yaml
+++ b/dev/rc/datarepo-api.yaml
@@ -19,6 +19,8 @@ env:
   RBS_ENABLED: true
   RBS_POOL_ID: datarepo_v3
   RBS_INSTANCE_URL: https://buffer.dsde-dev.broadinstitute.org
+  TERRA_COMMON_TRACING_STACKDRIVER_EXPORT_ENABLED: false
+  OPENCENCUS_SPRING_ENABLED: false
 serviceAccount:
   create: true
 rbac:

--- a/dev/se/datarepo-api.yaml
+++ b/dev/se/datarepo-api.yaml
@@ -18,6 +18,8 @@ env:
   RBS_ENABLED: true
   RBS_POOL_ID: datarepo_v3
   RBS_INSTANCE_URL: https://buffer.dsde-dev.broadinstitute.org
+  TERRA_COMMON_TRACING_STACKDRIVER_EXPORT_ENABLED: false
+  OPENCENCUS_SPRING_ENABLED: false
 serviceAccount:
   create: true
 rbac:

--- a/dev/sh/datarepo-api.yaml
+++ b/dev/sh/datarepo-api.yaml
@@ -16,6 +16,8 @@ env:
   RBS_ENABLED: true
   RBS_POOL_ID: datarepo_v1
   RBS_INSTANCE_URL: https://buffer.tools.integ.envs.broadinstitute.org
+  TERRA_COMMON_TRACING_STACKDRIVER_EXPORT_ENABLED: false
+  OPENCENCUS_SPRING_ENABLED: false
 serviceAccount:
   create: true
 rbac:

--- a/dev/tc/datarepo-api.yaml
+++ b/dev/tc/datarepo-api.yaml
@@ -18,6 +18,8 @@ env:
   RBS_ENABLED: true
   RBS_POOL_ID: datarepo_v3
   RBS_INSTANCE_URL: https://buffer.dsde-dev.broadinstitute.org
+  TERRA_COMMON_TRACING_STACKDRIVER_EXPORT_ENABLED: false
+  OPENCENCUS_SPRING_ENABLED: false
 serviceAccount:
   create: true
 rbac:

--- a/dev/tl/datarepo-api.yaml
+++ b/dev/tl/datarepo-api.yaml
@@ -18,6 +18,7 @@ env:
   RBS_ENABLED: true
   RBS_POOL_ID: datarepo_v3
   RBS_INSTANCE_URL: https://buffer.dsde-dev.broadinstitute.org
+  TERRA_COMMON_TRACING_STACKDRIVER_EXPORT_ENABLED: false
 serviceAccount:
   create: true
 rbac:

--- a/dev/tl/datarepo-api.yaml
+++ b/dev/tl/datarepo-api.yaml
@@ -19,6 +19,7 @@ env:
   RBS_POOL_ID: datarepo_v3
   RBS_INSTANCE_URL: https://buffer.dsde-dev.broadinstitute.org
   TERRA_COMMON_TRACING_STACKDRIVER_EXPORT_ENABLED: false
+  OPENCENCUS_SPRING_ENABLED: false
 serviceAccount:
   create: true
 rbac:

--- a/integration/integration-1/datarepo-api.yaml
+++ b/integration/integration-1/datarepo-api.yaml
@@ -18,6 +18,8 @@ env:
   RBS_ENABLED: true
   RBS_POOL_ID: datarepo_v1
   RBS_INSTANCE_URL: https://buffer.tools.integ.envs.broadinstitute.org
+  TERRA_COMMON_TRACING_STACKDRIVER_EXPORT_ENABLED: false
+  OPENCENCUS_SPRING_ENABLED: false
 serviceAccount:
   create: true
 rbac:

--- a/integration/integration-2/datarepo-api.yaml
+++ b/integration/integration-2/datarepo-api.yaml
@@ -18,6 +18,8 @@ env:
   RBS_ENABLED: true
   RBS_POOL_ID: datarepo_v1
   RBS_INSTANCE_URL: https://buffer.tools.integ.envs.broadinstitute.org
+  TERRA_COMMON_TRACING_STACKDRIVER_EXPORT_ENABLED: false
+  OPENCENCUS_SPRING_ENABLED: false
 serviceAccount:
   create: true
 rbac:

--- a/integration/integration-3/datarepo-api.yaml
+++ b/integration/integration-3/datarepo-api.yaml
@@ -18,6 +18,8 @@ env:
   RBS_ENABLED: true
   RBS_POOL_ID: datarepo_v1
   RBS_INSTANCE_URL: https://buffer.tools.integ.envs.broadinstitute.org
+  TERRA_COMMON_TRACING_STACKDRIVER_EXPORT_ENABLED: false
+  OPENCENCUS_SPRING_ENABLED: false
 serviceAccount:
   create: true
 rbac:

--- a/integration/integration-4/datarepo-api.yaml
+++ b/integration/integration-4/datarepo-api.yaml
@@ -16,6 +16,8 @@ env:
   RBS_ENABLED: true
   RBS_POOL_ID: datarepo_v3
   RBS_INSTANCE_URL: https://buffer.dsde-dev.broadinstitute.org
+  TERRA_COMMON_TRACING_STACKDRIVER_EXPORT_ENABLED: false
+  OPENCENCUS_SPRING_ENABLED: false
 serviceAccount:
   create: true
 rbac:

--- a/integration/integration-5/datarepo-api.yaml
+++ b/integration/integration-5/datarepo-api.yaml
@@ -16,6 +16,8 @@ env:
   RBS_ENABLED: true
   RBS_POOL_ID: datarepo_v3
   RBS_INSTANCE_URL: https://buffer.dsde-dev.broadinstitute.org
+  TERRA_COMMON_TRACING_STACKDRIVER_EXPORT_ENABLED: false
+  OPENCENCUS_SPRING_ENABLED: false
 serviceAccount:
   create: true
 rbac:

--- a/integration/integration-6/datarepo-api.yaml
+++ b/integration/integration-6/datarepo-api.yaml
@@ -17,6 +17,8 @@ env:
   RBS_ENABLED: true
   RBS_POOL_ID: datarepo_v1
   RBS_INSTANCE_URL: https://buffer.tools.integ.envs.broadinstitute.org
+  TERRA_COMMON_TRACING_STACKDRIVER_EXPORT_ENABLED: false
+  OPENCENCUS_SPRING_ENABLED: false
 serviceAccount:
   create: true
 rbac:

--- a/integration/integration-temp/datarepo-api.yaml
+++ b/integration/integration-temp/datarepo-api.yaml
@@ -19,6 +19,8 @@ env:
   RBS_ENABLED: true
   RBS_POOL_ID: datarepo_v1
   RBS_INSTANCE_URL: https://buffer.tools.integ.envs.broadinstitute.org
+  TERRA_COMMON_TRACING_STACKDRIVER_EXPORT_ENABLED: false
+  OPENCENCUS_SPRING_ENABLED: false
 serviceAccount:
   create: true
 rbac:

--- a/perf/datarepo/datarepo-api.yaml
+++ b/perf/datarepo/datarepo-api.yaml
@@ -20,6 +20,8 @@ env:
   RBS_ENABLED: true
   RBS_POOL_ID: datarepo_v1
   RBS_INSTANCE_URL: https://buffer.tools.integ.envs.broadinstitute.org
+  TERRA_COMMON_TRACING_STACKDRIVER_EXPORT_ENABLED: false
+  OPENCENCUS_SPRING_ENABLED: false
 serviceAccount:
   create: true
 rbac:


### PR DESCRIPTION
Getting rid of `Exception thrown by the service export io.opencensus.exporter.trace.stackdriver.StackdriverTraceExporter com.google.api.gax.rpc.PermissionDeniedException: io.grpc.StatusRuntimeException: PERMISSION_DENIED: The caller does not have permission` messages