### PR TITLE
DR-2755 Update to get latest configs and remove proxy wildcard

### DIFF
--- a/dev/cl/oidc-proxy.yaml
+++ b/dev/cl/oidc-proxy.yaml
@@ -17,7 +17,7 @@ ingress:
     kubernetes.io/ingress.global-static-ip-name: jade-dev-cl
     networking.gke.io/v1beta1.FrontendConfig: cl-jade-oidc-proxy
   paths:
-    - /*
+    - /
   hosts:
     - jade-cl.datarepo-dev.broadinstitute.org
 serviceAccount:

--- a/dev/eo/oidc-proxy.yaml
+++ b/dev/eo/oidc-proxy.yaml
@@ -17,7 +17,7 @@ ingress:
     kubernetes.io/ingress.global-static-ip-name: jade-dev-eo
     networking.gke.io/v1beta1.FrontendConfig: eo-jade-oidc-proxy
   paths:
-    - /*
+    - /
   hosts:
     - jade-eo.datarepo-dev.broadinstitute.org
 serviceAccount:

--- a/dev/nm/helmfile.yaml
+++ b/dev/nm/helmfile.yaml
@@ -12,7 +12,6 @@ releases:
     namespace: nm   # target namespace
     createNamespace: true
     chart: datarepo-helm/create-secret-manager-secret   # chart name
-    version: 0.0.6   #    Chart version
     missingFileHandler: Warn
     values:
       - create-secret-manager-secret.yaml      # Value files passed via --values
@@ -20,7 +19,6 @@ releases:
     namespace: nm   # target namespace
     createNamespace: true
     chart: datarepo-helm/gcloud-sqlproxy   # chart name
-    version: 0.19.7 #    Chart version
     missingFileHandler: Warn
     values:
       - gcloud-sqlproxy.yaml    # Value files passed via --values
@@ -28,7 +26,6 @@ releases:
     namespace: nm   # target namespace
     createNamespace: true
     chart: datarepo-helm/datarepo-api   # the chart name
-    version: 0.0.25    # chart version
     missingFileHandler: Warn
     values:
       - datarepo-api.yaml   # Value files passed via --values
@@ -36,7 +33,6 @@ releases:
     namespace: nm   # target namespace
     createNamespace: true
     chart: datarepo-helm/datarepo-ui   # the chart name
-    version: 0.0.14    # chart version
     missingFileHandler: Warn
     values:
       - datarepo-ui.yaml   # Value files passed via --values
@@ -44,7 +40,6 @@ releases:
     namespace: nm   # target namespace
     createNamespace: true
     chart: datarepo-helm/oidc-proxy   # the chart name
-    version: 0.0.25    # chart version
     missingFileHandler: Warn
     values:
       - oidc-proxy.yaml   # Value files passed via --values

--- a/dev/nm/oidc-proxy.yaml
+++ b/dev/nm/oidc-proxy.yaml
@@ -17,7 +17,7 @@ ingress:
     kubernetes.io/ingress.global-static-ip-name: jade-dev-nm
     networking.gke.io/v1beta1.FrontendConfig: nm-jade-oidc-proxy
   paths:
-    - /*
+    - /
   hosts:
     - jade-nm.datarepo-dev.broadinstitute.org
 serviceAccount:

--- a/dev/ok/helmfile.yaml
+++ b/dev/ok/helmfile.yaml
@@ -12,7 +12,6 @@ releases:
     namespace: ok   # target namespace
     createNamespace: true
     chart: datarepo-helm/create-secret-manager-secret   # chart name
-    version: 0.0.6   #    Chart version
     missingFileHandler: Warn
     values:
       - create-secret-manager-secret.yaml      # Value files passed via --values
@@ -20,7 +19,6 @@ releases:
     namespace: ok   # target namespace
     createNamespace: true
     chart: datarepo-helm/gcloud-sqlproxy   # chart name
-    version: 0.19.7 #    Chart version
     missingFileHandler: Warn
     values:
       - gcloud-sqlproxy.yaml    # Value files passed via --values
@@ -42,7 +40,6 @@ releases:
     namespace: ok   # target namespace
     createNamespace: true
     chart: datarepo-helm/oidc-proxy   # the chart name
-    version: 0.0.31    # chart version
     missingFileHandler: Warn
     values:
       - oidc-proxy.yaml   # Value files passed via --values

--- a/dev/ok/oidc-proxy.yaml
+++ b/dev/ok/oidc-proxy.yaml
@@ -17,7 +17,7 @@ ingress:
     kubernetes.io/ingress.global-static-ip-name: jade-dev-ok
     networking.gke.io/v1beta1.FrontendConfig: ok-jade-oidc-proxy
   paths:
-    - /*
+    - /
   hosts:
     - jade-ok.datarepo-dev.broadinstitute.org
 serviceAccount:

--- a/dev/se/helmfile.yaml
+++ b/dev/se/helmfile.yaml
@@ -12,7 +12,6 @@ releases:
     namespace: se   # target namespace
     createNamespace: true
     chart: datarepo-helm/create-secret-manager-secret   # chart name
-    version: 0.0.6   #    Chart version
     missingFileHandler: Warn
     values:
       - create-secret-manager-secret.yaml      # Value files passed via --values
@@ -20,7 +19,6 @@ releases:
     namespace: se   # target namespace
     createNamespace: true
     chart: datarepo-helm/gcloud-sqlproxy   # chart name
-    version: 0.19.7 #    Chart version
     missingFileHandler: Warn
     values:
       - gcloud-sqlproxy.yaml    # Value files passed via --values
@@ -28,7 +26,6 @@ releases:
     namespace: se   # target namespace
     createNamespace: true
     chart: datarepo-helm/datarepo-api   # the chart name
-    version: 0.0.25    # chart version
     missingFileHandler: Warn
     values:
       - datarepo-api.yaml   # Value files passed via --values
@@ -36,7 +33,6 @@ releases:
     namespace: se   # target namespace
     createNamespace: true
     chart: datarepo-helm/datarepo-ui   # the chart name
-    version: 0.0.14    # chart version
     missingFileHandler: Warn
     values:
       - datarepo-ui.yaml   # Value files passed via --values
@@ -44,7 +40,6 @@ releases:
     namespace: se   # target namespace
     createNamespace: true
     chart: datarepo-helm/oidc-proxy   # the chart name
-    version: 0.0.25    # chart version
     missingFileHandler: Warn
     values:
       - oidc-proxy.yaml   # Value files passed via --values

--- a/dev/se/oidc-proxy.yaml
+++ b/dev/se/oidc-proxy.yaml
@@ -17,7 +17,7 @@ ingress:
     kubernetes.io/ingress.global-static-ip-name: jade-dev-se
     networking.gke.io/v1beta1.FrontendConfig: se-jade-oidc-proxy
   paths:
-    - /*
+    - /
   hosts:
     - jade-se.datarepo-dev.broadinstitute.org
 serviceAccount:

--- a/dev/sh/oidc-proxy.yaml
+++ b/dev/sh/oidc-proxy.yaml
@@ -2,7 +2,8 @@
 env:
   PROXY_URL: http://sh-jade-datarepo-ui.sh:8080/
   PROXY_URL2: http://sh-jade-datarepo-api.sh:8080/api
-  PROXY_URL3: http://sh-jade-datarepo-api.sh:8080/register
+  PROXY_URL3: http://sh-jade-datarepo-api.sh:8080/ga4gh
+  PROXY_PATH3: /ga4gh
   LOG_LEVEL: info
   SERVER_NAME: jade.datarepo-dev.broadinstitute.org
   REMOTE_USER_CLAIM: sub
@@ -16,7 +17,7 @@ ingress:
     kubernetes.io/ingress.global-static-ip-name: jade-dev-sh
     networking.gke.io/v1beta1.FrontendConfig: sh-jade-oidc-proxy
   paths:
-    - /*
+    - /
   hosts:
     - jade-sh.datarepo-dev.broadinstitute.org
 serviceAccount:


### PR DESCRIPTION
This makes a best effort at getting active members' helmcharts up to date and removes the wildcard (`*`) from the odic-proxy configs.  Note: I didn't apply these, just want to make sure that we've got the latest in there