### PR TITLE
DR-2879 Set the cors regex variable for the dev deployment

### DIFF
--- a/dev/dev/devDeployment.yaml
+++ b/dev/dev/devDeployment.yaml
@@ -48,6 +48,7 @@ datarepo-api:
     OIDC_EXTRAAUTHPARAMS: prompt=login
     SENTRY_ENABLED: true
     SENTRY_ENVIRONMENT: development
+    CORS_REGEX: \\Qhttps://jade.datarepo-dev.broadinstitute.org\\E
   serviceAccount:
     create: true
   rbac:


### PR DESCRIPTION
This sets the variable so that if the origin header is sent on the request, only the dev instance is allowed.  Testing on dev before doing this on the upper environments.

I tested this on my personal env (it only really applies on `POST`/`PUT`/`DELETE`/`PATCH` requests...chrome doesn't send the `origin` header on GET)

![image](https://user-images.githubusercontent.com/5633787/213252164-b65d76cf-8b9d-4fa8-9ab2-4b85869418b6.png)
