### PR TITLE
[DR-2843] Run DUOS user sync hourly in TDR Dev

### DIFF
--- a/dev/dev/devDeployment.yaml
+++ b/dev/dev/devDeployment.yaml
@@ -48,6 +48,7 @@ datarepo-api:
     OIDC_EXTRAAUTHPARAMS: prompt=login
     SENTRY_ENABLED: true
     SENTRY_ENVIRONMENT: development
+    DUOS_SYNCUSERS_SCHEDULE: "@hourly"
   serviceAccount:
     create: true
   rbac:

--- a/dev/ok/datarepo-api.yaml
+++ b/dev/ok/datarepo-api.yaml
@@ -20,6 +20,7 @@ env:
   OIDC_AUTHORITYENDPOINT: https://accounts.google.com
   OIDC_ADDCLIENTIDTOSCOPE: false
   OIDC_EXTRAAUTHPARAMS: ""
+  DUOS_SYNCUSERS_SCHEDULE: "@hourly"
 serviceAccount:
   create: true
 rbac:


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/DR-2843

I just merged a PR which allows the DUOS user sync to be scheduled as a background task per deployment: https://github.com/DataBiosphere/jade-data-repo/pull/1421

This PR schedules that sync hourly in two environments:

- TDR Dev
- My `ok` developer environment -- since I continue to work on the DUOS integration, I saw it valuable to schedule the sync in my personal environment as well, but generally developers shouldn't need to do this in theirs unless they have a compelling reason.

Once we've had a period of runs in TDR Dev under our belt that we're happy with, we can schedule this sync in TDR Prod. 