### PR TITLE
[DR-3013] Add TPS env variables

### DIFF
--- a/dev/dev/devDeployment.yaml
+++ b/dev/dev/devDeployment.yaml
@@ -51,6 +51,8 @@ datarepo-api:
     SENTRY_ENVIRONMENT: development
     DUOS_SYNCUSERS_SCHEDULE: "@hourly"
     DATAREPO_COMPACTIDPREFIXALLOWLIST_0_: foo.0
+    TPS_ENABLED: true
+    TPS_BASE_PATH: https://tps.dsde-dev.broadinstitute.org
   serviceAccount:
     create: true
   rbac:

--- a/dev/nm/datarepo-api.yaml
+++ b/dev/nm/datarepo-api.yaml
@@ -23,6 +23,8 @@ env:
   OIDC_ADDCLIENTIDTOSCOPE: true
   OIDC_EXTRAAUTHPARAMS: prompt=login
   DATAREPO_COMPACTIDPREFIXALLOWLIST_0_: foo.0
+  TPS_ENABLED: true
+  TPS_BASE_PATH: https://tps.dsde-dev.broadinstitute.org
 serviceAccount:
   create: true
 rbac:

--- a/dev/ok/datarepo-api.yaml
+++ b/dev/ok/datarepo-api.yaml
@@ -22,6 +22,8 @@ env:
   OIDC_ADDCLIENTIDTOSCOPE: true
   OIDC_EXTRAAUTHPARAMS: prompt=login
   DUOS_SYNCUSERS_SCHEDULE: "@hourly"
+  TPS_ENABLED: true
+  TPS_BASE_PATH: https://tps.dsde-dev.broadinstitute.org
 serviceAccount:
   create: true
 rbac:

--- a/dev/ps/datarepo-api.yaml
+++ b/dev/ps/datarepo-api.yaml
@@ -24,6 +24,8 @@ env:
   OIDC_AUTHORITYENDPOINT: https://terradevb2c.b2clogin.com/terradevb2c.onmicrosoft.com/B2C_1A_SIGNUP_SIGNIN_TDR/v2.0
   OIDC_ADDCLIENTIDTOSCOPE: true
   OIDC_EXTRAAUTHPARAMS: prompt=login
+  TPS_ENABLED: true
+  TPS_BASE_PATH: https://tps.dsde-dev.broadinstitute.org
 serviceAccount:
   create: true
 rbac:

--- a/dev/se/datarepo-api.yaml
+++ b/dev/se/datarepo-api.yaml
@@ -24,6 +24,8 @@ env:
   OIDC_AUTHORITYENDPOINT: https://terradevb2c.b2clogin.com/terradevb2c.onmicrosoft.com/B2C_1A_SIGNUP_SIGNIN_TDR/v2.0
   OIDC_ADDCLIENTIDTOSCOPE: true
   OIDC_EXTRAAUTHPARAMS: prompt=login
+  TPS_ENABLED: true
+  TPS_BASE_PATH: https://tps.dsde-dev.broadinstitute.org
 serviceAccount:
   create: true
 rbac:

--- a/dev/sh/datarepo-api.yaml
+++ b/dev/sh/datarepo-api.yaml
@@ -22,6 +22,8 @@ env:
   OIDC_AUTHORITYENDPOINT: https://terradevb2c.b2clogin.com/terradevb2c.onmicrosoft.com/B2C_1A_SIGNUP_SIGNIN_TDR/v2.0
   OIDC_ADDCLIENTIDTOSCOPE: true
   OIDC_EXTRAAUTHPARAMS: prompt=login
+  TPS_ENABLED: true
+  TPS_BASE_PATH: https://tps.dsde-dev.broadinstitute.org
 serviceAccount:
   create: true
 rbac:

--- a/fakeprod/datarepo-api.yaml
+++ b/fakeprod/datarepo-api.yaml
@@ -21,6 +21,7 @@ env:
   RBS_ENABLED: false
   RBS_POOL_ID: datarepo_v1
   RBS_INSTANCE_URL: https://buffer.dsde-prod.broadinstitute.org
+  TPS_ENABLED: false
 serviceAccount:
   create: true
 rbac:

--- a/integration/integration-1/datarepo-api.yaml
+++ b/integration/integration-1/datarepo-api.yaml
@@ -24,6 +24,8 @@ env:
   OIDC_AUTHORITYENDPOINT: https://terradevb2c.b2clogin.com/terradevb2c.onmicrosoft.com/B2C_1A_SIGNUP_SIGNIN_TDR/v2.0
   OIDC_ADDCLIENTIDTOSCOPE: true
   OIDC_EXTRAAUTHPARAMS: prompt=login
+  TPS_ENABLED: true
+  TPS_BASE_PATH: https://tps.dsde-dev.broadinstitute.org
 serviceAccount:
   create: true
 rbac:

--- a/integration/integration-2/datarepo-api.yaml
+++ b/integration/integration-2/datarepo-api.yaml
@@ -25,6 +25,8 @@ env:
   OIDC_ADDCLIENTIDTOSCOPE: true
   OIDC_EXTRAAUTHPARAMS: prompt=login
   SAM_OPERATIONTIMEOUTSECONDS: 120
+  TPS_ENABLED: true
+  TPS_BASE_PATH: https://tps.dsde-dev.broadinstitute.org
 serviceAccount:
   create: true
 rbac:

--- a/integration/integration-3/datarepo-api.yaml
+++ b/integration/integration-3/datarepo-api.yaml
@@ -25,6 +25,8 @@ env:
   OIDC_ADDCLIENTIDTOSCOPE: true
   OIDC_EXTRAAUTHPARAMS: prompt=login
   SAM_OPERATIONTIMEOUTSECONDS: 120
+  TPS_ENABLED: true
+  TPS_BASE_PATH: https://tps.dsde-dev.broadinstitute.org
 serviceAccount:
   create: true
 rbac:

--- a/integration/integration-4/datarepo-api.yaml
+++ b/integration/integration-4/datarepo-api.yaml
@@ -23,6 +23,8 @@ env:
   OIDC_ADDCLIENTIDTOSCOPE: true
   OIDC_EXTRAAUTHPARAMS: prompt=login
   SAM_OPERATIONTIMEOUTSECONDS: 120
+  TPS_ENABLED: true
+  TPS_BASE_PATH: https://tps.dsde-dev.broadinstitute.org
 serviceAccount:
   create: true
 rbac:

--- a/integration/integration-5/datarepo-api.yaml
+++ b/integration/integration-5/datarepo-api.yaml
@@ -23,6 +23,8 @@ env:
   OIDC_ADDCLIENTIDTOSCOPE: true
   OIDC_EXTRAAUTHPARAMS: prompt=login
   SAM_OPERATIONTIMEOUTSECONDS: 120
+  TPS_ENABLED: true
+  TPS_BASE_PATH: https://tps.dsde-dev.broadinstitute.org
 serviceAccount:
   create: true
 rbac:

--- a/integration/integration-6/datarepo-api.yaml
+++ b/integration/integration-6/datarepo-api.yaml
@@ -24,6 +24,8 @@ env:
   OIDC_ADDCLIENTIDTOSCOPE: true
   OIDC_EXTRAAUTHPARAMS: prompt=login
   SAM_OPERATIONTIMEOUTSECONDS: 120
+  TPS_ENABLED: true
+  TPS_BASE_PATH: https://tps.dsde-dev.broadinstitute.org
 serviceAccount:
   create: true
 rbac:

--- a/perf/datarepo/datarepo-api.yaml
+++ b/perf/datarepo/datarepo-api.yaml
@@ -28,6 +28,8 @@ env:
   OIDC_ADDCLIENTIDTOSCOPE: true
   OIDC_EXTRAAUTHPARAMS: prompt=login
   SAM_OPERATIONTIMEOUTSECONDS: 120
+  TPS_ENABLED: true
+  TPS_BASE_PATH: https://tps.dsde-dev.broadinstitute.org
 serviceAccount:
   create: true
 rbac:


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/DR-3032

Add the `TPS_BASE_PATH` and `TPS_ENABLED` for dev, personal dev deployments, integration and perf. These environment variables were added in https://github.com/DataBiosphere/jade-data-repo/pull/1454 for integration with the Terra Policy Service. Currently, there is only a dev environment.

There is a follow-on ticket to update alpha, staging and prod once those TPS deployments exist: https://broadworkbench.atlassian.net/browse/DR-3035