### PR TITLE
[DR-3029] Remove TPS_ENABLED variable

### DIFF
--- a/dev/dev/devDeployment.yaml
+++ b/dev/dev/devDeployment.yaml
@@ -62,7 +62,6 @@ datarepo-api:
     SENTRY_DSN: https://a3d46c70bbc74f32bfc5153fb8f915a6@o54426.ingest.sentry.io/4504044616089600
     DUOS_SYNCUSERS_SCHEDULE: "@hourly"
     DATAREPO_COMPACTIDPREFIXALLOWLIST_0_: foo.0
-    TPS_ENABLED: true
     TPS_BASE_PATH: https://tps.dsde-dev.broadinstitute.org
   serviceAccount:
     create: true

--- a/dev/nm/datarepo-api.yaml
+++ b/dev/nm/datarepo-api.yaml
@@ -25,7 +25,6 @@ env:
   OIDC_ADDCLIENTIDTOSCOPE: true
   OIDC_EXTRAAUTHPARAMS: prompt=login
   DATAREPO_COMPACTIDPREFIXALLOWLIST_0_: foo.0
-  TPS_ENABLED: true
   TPS_BASE_PATH: https://tps.dsde-dev.broadinstitute.org
 serviceAccount:
   create: true

--- a/dev/ok/datarepo-api.yaml
+++ b/dev/ok/datarepo-api.yaml
@@ -24,7 +24,6 @@ env:
   OIDC_ADDCLIENTIDTOSCOPE: true
   OIDC_EXTRAAUTHPARAMS: prompt=login
   DUOS_SYNCUSERS_SCHEDULE: "@hourly"
-  TPS_ENABLED: true
   TPS_BASE_PATH: https://tps.dsde-dev.broadinstitute.org
 serviceAccount:
   create: true

--- a/dev/ps/datarepo-api.yaml
+++ b/dev/ps/datarepo-api.yaml
@@ -26,7 +26,6 @@ env:
   OIDC_AUTHORITYENDPOINT: https://terradevb2c.b2clogin.com/terradevb2c.onmicrosoft.com/B2C_1A_SIGNUP_SIGNIN_TDR/v2.0
   OIDC_ADDCLIENTIDTOSCOPE: true
   OIDC_EXTRAAUTHPARAMS: prompt=login
-  TPS_ENABLED: true
   TPS_BASE_PATH: https://tps.dsde-dev.broadinstitute.org
 serviceAccount:
   create: true

--- a/dev/se/datarepo-api.yaml
+++ b/dev/se/datarepo-api.yaml
@@ -26,7 +26,6 @@ env:
   OIDC_AUTHORITYENDPOINT: https://terradevb2c.b2clogin.com/terradevb2c.onmicrosoft.com/B2C_1A_SIGNUP_SIGNIN_TDR/v2.0
   OIDC_ADDCLIENTIDTOSCOPE: true
   OIDC_EXTRAAUTHPARAMS: prompt=login
-  TPS_ENABLED: true
   TPS_BASE_PATH: https://tps.dsde-dev.broadinstitute.org
 serviceAccount:
   create: true

--- a/dev/sh/datarepo-api.yaml
+++ b/dev/sh/datarepo-api.yaml
@@ -24,7 +24,6 @@ env:
   OIDC_AUTHORITYENDPOINT: https://terradevb2c.b2clogin.com/terradevb2c.onmicrosoft.com/B2C_1A_SIGNUP_SIGNIN_TDR/v2.0
   OIDC_ADDCLIENTIDTOSCOPE: true
   OIDC_EXTRAAUTHPARAMS: prompt=login
-  TPS_ENABLED: true
   TPS_BASE_PATH: https://tps.dsde-dev.broadinstitute.org
 serviceAccount:
   create: true

--- a/fakeprod/datarepo-api.yaml
+++ b/fakeprod/datarepo-api.yaml
@@ -21,7 +21,6 @@ env:
   RBS_ENABLED: false
   RBS_POOL_ID: datarepo_v1
   RBS_INSTANCE_URL: https://buffer.dsde-prod.broadinstitute.org
-  TPS_ENABLED: false
 serviceAccount:
   create: true
 rbac:

--- a/integration/integration-1/datarepo-api.yaml
+++ b/integration/integration-1/datarepo-api.yaml
@@ -26,7 +26,6 @@ env:
   OIDC_AUTHORITYENDPOINT: https://terradevb2c.b2clogin.com/terradevb2c.onmicrosoft.com/B2C_1A_SIGNUP_SIGNIN_TDR/v2.0
   OIDC_ADDCLIENTIDTOSCOPE: true
   OIDC_EXTRAAUTHPARAMS: prompt=login
-  TPS_ENABLED: true
   TPS_BASE_PATH: https://tps.dsde-dev.broadinstitute.org
 serviceAccount:
   create: true

--- a/integration/integration-2/datarepo-api.yaml
+++ b/integration/integration-2/datarepo-api.yaml
@@ -27,7 +27,6 @@ env:
   OIDC_ADDCLIENTIDTOSCOPE: true
   OIDC_EXTRAAUTHPARAMS: prompt=login
   SAM_OPERATIONTIMEOUTSECONDS: 120
-  TPS_ENABLED: true
   TPS_BASE_PATH: https://tps.dsde-dev.broadinstitute.org
 serviceAccount:
   create: true

--- a/integration/integration-3/datarepo-api.yaml
+++ b/integration/integration-3/datarepo-api.yaml
@@ -27,7 +27,6 @@ env:
   OIDC_ADDCLIENTIDTOSCOPE: true
   OIDC_EXTRAAUTHPARAMS: prompt=login
   SAM_OPERATIONTIMEOUTSECONDS: 120
-  TPS_ENABLED: true
   TPS_BASE_PATH: https://tps.dsde-dev.broadinstitute.org
 serviceAccount:
   create: true

--- a/integration/integration-4/datarepo-api.yaml
+++ b/integration/integration-4/datarepo-api.yaml
@@ -25,7 +25,6 @@ env:
   OIDC_ADDCLIENTIDTOSCOPE: true
   OIDC_EXTRAAUTHPARAMS: prompt=login
   SAM_OPERATIONTIMEOUTSECONDS: 120
-  TPS_ENABLED: true
   TPS_BASE_PATH: https://tps.dsde-dev.broadinstitute.org
 serviceAccount:
   create: true

--- a/integration/integration-5/datarepo-api.yaml
+++ b/integration/integration-5/datarepo-api.yaml
@@ -25,7 +25,6 @@ env:
   OIDC_ADDCLIENTIDTOSCOPE: true
   OIDC_EXTRAAUTHPARAMS: prompt=login
   SAM_OPERATIONTIMEOUTSECONDS: 120
-  TPS_ENABLED: true
   TPS_BASE_PATH: https://tps.dsde-dev.broadinstitute.org
 serviceAccount:
   create: true

--- a/integration/integration-6/datarepo-api.yaml
+++ b/integration/integration-6/datarepo-api.yaml
@@ -26,7 +26,6 @@ env:
   OIDC_ADDCLIENTIDTOSCOPE: true
   OIDC_EXTRAAUTHPARAMS: prompt=login
   SAM_OPERATIONTIMEOUTSECONDS: 120
-  TPS_ENABLED: true
   TPS_BASE_PATH: https://tps.dsde-dev.broadinstitute.org
 serviceAccount:
   create: true

--- a/perf/datarepo/datarepo-api.yaml
+++ b/perf/datarepo/datarepo-api.yaml
@@ -30,7 +30,6 @@ env:
   OIDC_ADDCLIENTIDTOSCOPE: true
   OIDC_EXTRAAUTHPARAMS: prompt=login
   SAM_OPERATIONTIMEOUTSECONDS: 120
-  TPS_ENABLED: true
   TPS_BASE_PATH: https://tps.dsde-dev.broadinstitute.org
 serviceAccount:
   create: true


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/DR-3029

Since the Terra Policy Service is now available in all environments, this flag is no longer needed in TDR.

This must be merged after https://github.com/DataBiosphere/jade-data-repo/pull/1509, which removes all references to the enabled flag.