### PR TITLE
[DDO-3245] Add note about dev/dev/* being unused

### DIFF
--- a/dev/dev/README.md
+++ b/dev/dev/README.md
@@ -1,0 +1,5 @@
+## UNUSED
+
+This files are now unused. See [DDO-3231](https://broadworkbench.atlassian.net/jira/software/c/projects/DDO/issues/DDO-3231).
+
+You'll find the equivalent dev.yaml file [here](https://github.com/broadinstitute/terra-helmfile/tree/master/values/app/datarepo/live).


### PR DESCRIPTION
Don't want to delete the files just yet because there's still CI that hits them and they might be good to reference.