### PR TITLE
[DR-3413] Remove elasticsearch from dev configuration

### DIFF
--- a/dev/dev/devDeployment.yaml
+++ b/dev/dev/devDeployment.yaml
@@ -45,7 +45,6 @@ datarepo-api:
     AZURE_MONITORING_LOGCOLLECTIONCONFIGS_3__REGION: southcentralus
     AZURE_MONITORING_LOGCOLLECTIONCONFIGS_3__TARGETSTORAGEACCOUNTRESOURCEID: /subscriptions/c5f8eca3-f512-48cb-b01f-f19f1af9014c/resourceGroups/terra-dev-protected-data-logs-rg/providers/Microsoft.Storage/storageAccounts/ltslogsdevsthcntrlus
     FEATURES_SEARCH_API: enabled
-    ELASTICSEARCH_HOSTNAME: 10.0.21.132
     RBS_ENABLED: true
     RBS_POOL_ID: datarepo_v3
     RBS_INSTANCE_URL: https://buffer.dsde-dev.broadinstitute.org
@@ -123,5 +122,3 @@ oidc-proxy:
   rbac:
     create: true
     pspEnabled: true
-de-elasticsearch:
-  enabled: true


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/DR-3413

I believe this config is no longer being used now that our dev environment is managed in the terra-helmfile repo, just removing it here for consistency with: https://github.com/broadinstitute/terra-helmfile/pull/4906/files