### PR TITLE
Prod-934: TDR personal devs, int, perf environments settings update: GKE 1.25+ incompatible with PodSecurityPolicies

### DIFF
--- a/alpha/datarepomonitoring/kube-prometheus-stack.yaml
+++ b/alpha/datarepomonitoring/kube-prometheus-stack.yaml
@@ -74,8 +74,8 @@ grafana:
       jvm-dashboard:
         url: https://raw.githubusercontent.com/broadinstitute/datarepo-helm-definitions/master/dashboards/jvm-dashboard.json
   rbac:
-    create: true
-    pspEnabled: true
+    create: false
+    pspEnabled: false
   plugins: ["doitintl-bigquery-datasource"]
   env:
     GF_USERS_AUTO_ASSIGN_ORG_ROLE: "Editor"

--- a/dev/dev/devDeployment.yaml
+++ b/dev/dev/devDeployment.yaml
@@ -10,7 +10,7 @@ gcloud-sqlproxy:
       # Port number for the proxy to expose for this instance.
       port: 5432
   rbac:
-    create: true
+    create: false
   networkPolicy:
     enabled: false
   existingSecret: sqlproxy-sa-dev
@@ -68,8 +68,8 @@ datarepo-api:
   serviceAccount:
     create: true
   rbac:
-    create: true
-    pspEnabled: true
+    create: false
+    pspEnabled: false
   existingSecretDB: "database-pwd-dev"
   existingDatarepoDbSecretKey: "datarepopassword"
   existingStairwayDbSecretKey: "stairwaypassword"
@@ -94,7 +94,7 @@ datarepo-ui:
   serviceAccount:
     create: true
   rbac:
-    create: true
+    create: false
 oidc-proxy:
   enabled: true
   env:
@@ -122,5 +122,5 @@ oidc-proxy:
   serviceAccount:
     create: true
   rbac:
-    create: true
-    pspEnabled: true
+    create: false
+    pspEnabled: false

--- a/dev/dev/devDeployment.yaml
+++ b/dev/dev/devDeployment.yaml
@@ -10,7 +10,8 @@ gcloud-sqlproxy:
       # Port number for the proxy to expose for this instance.
       port: 5432
   rbac:
-    create: false
+    create: true
+    pspEnabled: false
   networkPolicy:
     enabled: false
   existingSecret: sqlproxy-sa-dev
@@ -68,7 +69,7 @@ datarepo-api:
   serviceAccount:
     create: true
   rbac:
-    create: false
+    create: true
     pspEnabled: false
   existingSecretDB: "database-pwd-dev"
   existingDatarepoDbSecretKey: "datarepopassword"

--- a/dev/monitoring/kube-prometheus-stack.yaml
+++ b/dev/monitoring/kube-prometheus-stack.yaml
@@ -60,8 +60,8 @@ grafana:
       jvm-dashboard:
         url: https://raw.githubusercontent.com/broadinstitute/datarepo-helm-definitions/master/dashboards/jvm-dashboard.json
   rbac:
-    create: true
-    pspEnabled: true
+    create: false
+    pspEnabled: false
   plugins:
     - doitintl-bigquery-datasource
     - grafana-github-datasource

--- a/dev/nm/datarepo-api.yaml
+++ b/dev/nm/datarepo-api.yaml
@@ -31,7 +31,7 @@ serviceAccount:
   create: true
 rbac:
   create: true
-  pspEnabled: true
+  pspEnabled: false
 existingSecretDB: "database-pwd-nm"
 existingDatarepoDbSecretKey: "datarepopassword"
 existingStairwayDbSecretKey: "stairwaypassword"

--- a/dev/nm/datarepo-ui.yaml
+++ b/dev/nm/datarepo-ui.yaml
@@ -6,4 +6,4 @@ proxyPass:
 serviceAccount:
   create: true
 rbac:
-  create: true
+  create: false

--- a/dev/nm/gcloud-sqlproxy.yaml
+++ b/dev/nm/gcloud-sqlproxy.yaml
@@ -13,6 +13,7 @@ cloudsql:
       port: 5432
 rbac:
   create: true
+  pspEnabled: false
 networkPolicy:
   enabled: false
 nodeSelector:

--- a/dev/nm/oidc-proxy.yaml
+++ b/dev/nm/oidc-proxy.yaml
@@ -23,5 +23,5 @@ ingress:
 serviceAccount:
   create: true
 rbac:
-  create: true
-  pspEnabled: true
+  create: false
+  pspEnabled: false

--- a/dev/ok/datarepo-api.yaml
+++ b/dev/ok/datarepo-api.yaml
@@ -30,7 +30,7 @@ serviceAccount:
   create: true
 rbac:
   create: true
-  pspEnabled: true
+  pspEnabled: false
 existingSecretDB: "database-pwd-ok"
 existingDatarepoDbSecretKey: "datarepopassword"
 existingStairwayDbSecretKey: "stairwaypassword"

--- a/dev/ok/datarepo-ui.yaml
+++ b/dev/ok/datarepo-ui.yaml
@@ -6,4 +6,4 @@ proxyPass:
 serviceAccount:
   create: true
 rbac:
-  create: true
+  create: false

--- a/dev/ok/gcloud-sqlproxy.yaml
+++ b/dev/ok/gcloud-sqlproxy.yaml
@@ -13,5 +13,6 @@ cloudsql:
       port: 5432
 rbac:
   create: true
+  pspEnabled: false
 networkPolicy:
   enabled: false

--- a/dev/ok/oidc-proxy.yaml
+++ b/dev/ok/oidc-proxy.yaml
@@ -23,5 +23,5 @@ ingress:
 serviceAccount:
   create: true
 rbac:
-  create: true
-  pspEnabled: true
+  create: false
+  pspEnabled: false

--- a/dev/ps/datarepo-api.yaml
+++ b/dev/ps/datarepo-api.yaml
@@ -32,7 +32,7 @@ serviceAccount:
   create: true
 rbac:
   create: true
-  pspEnabled: true
+  pspEnabled: false
 existingSecretDB: "database-pwd-ps"
 existingDatarepoDbSecretKey: "datarepopassword"
 existingStairwayDbSecretKey: "stairwaypassword"

--- a/dev/ps/datarepo-ui.yaml
+++ b/dev/ps/datarepo-ui.yaml
@@ -8,4 +8,4 @@ proxyPass:
 serviceAccount:
   create: true
 rbac:
-  create: true
+  create: false

--- a/dev/ps/gcloud-sqlproxy.yaml
+++ b/dev/ps/gcloud-sqlproxy.yaml
@@ -13,5 +13,6 @@ cloudsql:
       port: 5432
 rbac:
   create: true
+  pspEnabled: false
 networkPolicy:
   enabled: false

--- a/dev/ps/oidc-proxy.yaml
+++ b/dev/ps/oidc-proxy.yaml
@@ -22,5 +22,5 @@ ingress:
 serviceAccount:
   create: true
 rbac:
-  create: true
-  pspEnabled: true
+  create: false
+  pspEnabled: false

--- a/dev/se/datarepo-api.yaml
+++ b/dev/se/datarepo-api.yaml
@@ -32,7 +32,7 @@ serviceAccount:
   create: true
 rbac:
   create: true
-  pspEnabled: true
+  pspEnabled: false
 existingSecretDB: "database-pwd-se"
 existingDatarepoDbSecretKey: "datarepopassword"
 existingStairwayDbSecretKey: "stairwaypassword"

--- a/dev/se/datarepo-ui.yaml
+++ b/dev/se/datarepo-ui.yaml
@@ -8,4 +8,4 @@ proxyPass:
 serviceAccount:
   create: true
 rbac:
-  create: true
+  create: false

--- a/dev/se/gcloud-sqlproxy.yaml
+++ b/dev/se/gcloud-sqlproxy.yaml
@@ -13,5 +13,6 @@ cloudsql:
       port: 5432
 rbac:
   create: true
+  pspEnabled: false
 networkPolicy:
   enabled: false

--- a/dev/se/oidc-proxy.yaml
+++ b/dev/se/oidc-proxy.yaml
@@ -23,5 +23,5 @@ ingress:
 serviceAccount:
   create: true
 rbac:
-  create: true
-  pspEnabled: true
+  create: false
+  pspEnabled: false

--- a/dev/sh/datarepo-api.yaml
+++ b/dev/sh/datarepo-api.yaml
@@ -32,7 +32,7 @@ serviceAccount:
   create: true
 rbac:
   create: true
-  pspEnabled: true
+  pspEnabled: false
 existingSecretDB: "database-pwd-sh"
 existingDatarepoDbSecretKey: "datarepopassword"
 existingStairwayDbSecretKey: "stairwaypassword"

--- a/dev/sh/datarepo-ui.yaml
+++ b/dev/sh/datarepo-ui.yaml
@@ -6,4 +6,4 @@ proxyPass:
 serviceAccount:
   create: true
 rbac:
-  create: true
+  create: false

--- a/dev/sh/gcloud-sqlproxy.yaml
+++ b/dev/sh/gcloud-sqlproxy.yaml
@@ -13,5 +13,6 @@ cloudsql:
       port: 5432
 rbac:
   create: true
+  pspEnabled: false
 networkPolicy:
   enabled: false

--- a/dev/sh/oidc-proxy.yaml
+++ b/dev/sh/oidc-proxy.yaml
@@ -23,5 +23,5 @@ ingress:
 serviceAccount:
   create: true
 rbac:
-  create: true
-  pspEnabled: true
+  create: false
+  pspEnabled: false

--- a/fakeprod/datarepo-api.yaml
+++ b/fakeprod/datarepo-api.yaml
@@ -25,7 +25,7 @@ serviceAccount:
   create: true
 rbac:
   create: true
-  pspEnabled: true
+  pspEnabled: false
 existingSecretDB: "api-secrets"
 existingDatarepoDbSecretKey: "datarepo-password"
 existingStairwayDbSecretKey: "stairway-password"

--- a/fakeprod/datarepo-api.yaml
+++ b/fakeprod/datarepo-api.yaml
@@ -25,7 +25,7 @@ serviceAccount:
   create: true
 rbac:
   create: true
-  pspEnabled: false
+  pspEnabled: true
 existingSecretDB: "api-secrets"
 existingDatarepoDbSecretKey: "datarepo-password"
 existingStairwayDbSecretKey: "stairway-password"

--- a/fakeprod/datarepo-ui.yaml
+++ b/fakeprod/datarepo-ui.yaml
@@ -6,4 +6,4 @@ proxyPass:
 serviceAccount:
   create: true
 rbac:
-  create: false
+  create: true

--- a/fakeprod/datarepo-ui.yaml
+++ b/fakeprod/datarepo-ui.yaml
@@ -6,4 +6,4 @@ proxyPass:
 serviceAccount:
   create: true
 rbac:
-  create: true
+  create: false

--- a/fakeprod/gcloud-sqlproxy.yaml
+++ b/fakeprod/gcloud-sqlproxy.yaml
@@ -11,7 +11,6 @@ cloudsql:
       port: 5432
 rbac:
   create: true
-  pspEnabled: false
 networkPolicy:
   enabled: false
 existingSecret: sql-proxy-sa

--- a/fakeprod/gcloud-sqlproxy.yaml
+++ b/fakeprod/gcloud-sqlproxy.yaml
@@ -11,6 +11,7 @@ cloudsql:
       port: 5432
 rbac:
   create: true
+  pspEnabled: false
 networkPolicy:
   enabled: false
 existingSecret: sql-proxy-sa

--- a/fakeprod/oidc-proxy.yaml
+++ b/fakeprod/oidc-proxy.yaml
@@ -21,5 +21,5 @@ ingress:
 serviceAccount:
   create: true
 rbac:
-  create: true
-  pspEnabled: true
+  create: false
+  pspEnabled: false

--- a/fakeprod/oidc-proxy.yaml
+++ b/fakeprod/oidc-proxy.yaml
@@ -21,5 +21,5 @@ ingress:
 serviceAccount:
   create: true
 rbac:
-  create: false
-  pspEnabled: false
+  create: true
+  pspEnabled: true

--- a/integration/datarepomonitoring/datarepomonitoring.yaml
+++ b/integration/datarepomonitoring/datarepomonitoring.yaml
@@ -75,7 +75,7 @@ kube-prometheus-stack:
   grafana:
     rbac:
       create: true
-      pspEnabled: true
+      pspEnabled: false
     plugins: ["doitintl-bigquery-datasource"]
     env:
       GF_USERS_AUTO_ASSIGN_ORG_ROLE: "Editor"

--- a/integration/helmfile.yaml
+++ b/integration/helmfile.yaml
@@ -26,7 +26,7 @@ releases:
   - name: descheduler   # release name
     namespace: kube-system   # target namespace
     chart: descheduler/descheduler   # chart name
-    version: v0.20.0 # chart version (note more recent charts break)
+    version: v0.29.0 # chart version (note more recent charts break)
     missingFileHandler: Warn
     values:
       - schedule: "0 * * * *"

--- a/integration/integration-1/datarepo-api.yaml
+++ b/integration/integration-1/datarepo-api.yaml
@@ -32,7 +32,7 @@ serviceAccount:
   create: true
 rbac:
   create: true
-  pspEnabled: true
+  pspEnabled: false
 existingSecretDB: "database-pwd-integration-1"
 existingDatarepoDbSecretKey: "datarepopassword"
 existingStairwayDbSecretKey: "stairwaypassword"

--- a/integration/integration-1/datarepo-ui.yaml
+++ b/integration/integration-1/datarepo-ui.yaml
@@ -7,6 +7,6 @@ proxyPass:
 serviceAccount:
   create: true
 rbac:
-  create: true
+  create: false
 nodeSelector:
   cloud.google.com/gke-nodepool: integration-node

--- a/integration/integration-1/gcloud-sqlproxy.yaml
+++ b/integration/integration-1/gcloud-sqlproxy.yaml
@@ -11,6 +11,7 @@ cloudsql:
     port: 5432
 rbac:
   create: true
+  pspEnabled: false
 networkPolicy:
   enabled: false
 nodeSelector:

--- a/integration/integration-1/oidc-proxy.yaml
+++ b/integration/integration-1/oidc-proxy.yaml
@@ -23,7 +23,7 @@ ingress:
 serviceAccount:
   create: true
 rbac:
-  create: true
-  pspEnabled: true
+  create: false
+  pspEnabled: false
 nodeSelector:
   cloud.google.com/gke-nodepool: integration-node

--- a/integration/integration-2/datarepo-api.yaml
+++ b/integration/integration-2/datarepo-api.yaml
@@ -33,7 +33,7 @@ serviceAccount:
   create: true
 rbac:
   create: true
-  pspEnabled: true
+  pspEnabled: false
 existingSecretDB: "database-pwd-integration-2"
 existingDatarepoDbSecretKey: "datarepopassword"
 existingStairwayDbSecretKey: "stairwaypassword"

--- a/integration/integration-2/datarepo-ui.yaml
+++ b/integration/integration-2/datarepo-ui.yaml
@@ -7,6 +7,6 @@ proxyPass:
 serviceAccount:
   create: true
 rbac:
-  create: true
+  create: false
 nodeSelector:
   cloud.google.com/gke-nodepool: integration-node-2

--- a/integration/integration-2/gcloud-sqlproxy.yaml
+++ b/integration/integration-2/gcloud-sqlproxy.yaml
@@ -11,6 +11,7 @@ cloudsql:
     port: 5432
 rbac:
   create: true
+  pspEnabled: false
 networkPolicy:
   enabled: false
 nodeSelector:

--- a/integration/integration-2/oidc-proxy.yaml
+++ b/integration/integration-2/oidc-proxy.yaml
@@ -23,7 +23,7 @@ ingress:
 serviceAccount:
   create: true
 rbac:
-  create: true
-  pspEnabled: true
+  create: false
+  pspEnabled: false
 nodeSelector:
   cloud.google.com/gke-nodepool: integration-node-2

--- a/integration/integration-3/datarepo-api.yaml
+++ b/integration/integration-3/datarepo-api.yaml
@@ -33,7 +33,7 @@ serviceAccount:
   create: true
 rbac:
   create: true
-  pspEnabled: true
+  pspEnabled: false
 existingSecretDB: "database-pwd-integration-3"
 existingDatarepoDbSecretKey: "datarepopassword"
 existingStairwayDbSecretKey: "stairwaypassword"

--- a/integration/integration-3/datarepo-ui.yaml
+++ b/integration/integration-3/datarepo-ui.yaml
@@ -7,6 +7,6 @@ proxyPass:
 serviceAccount:
   create: true
 rbac:
-  create: true
+  create: false
 nodeSelector:
   cloud.google.com/gke-nodepool: integration-node

--- a/integration/integration-3/gcloud-sqlproxy.yaml
+++ b/integration/integration-3/gcloud-sqlproxy.yaml
@@ -11,6 +11,7 @@ cloudsql:
     port: 5432
 rbac:
   create: true
+  pspEnabled: false
 networkPolicy:
   enabled: false
 nodeSelector:

--- a/integration/integration-3/oidc-proxy.yaml
+++ b/integration/integration-3/oidc-proxy.yaml
@@ -23,7 +23,7 @@ ingress:
 serviceAccount:
   create: true
 rbac:
-  create: true
-  pspEnabled: true
+  create: false
+  pspEnabled: false
 nodeSelector:
   cloud.google.com/gke-nodepool: integration-node

--- a/integration/integration-4/datarepo-api.yaml
+++ b/integration/integration-4/datarepo-api.yaml
@@ -31,7 +31,7 @@ serviceAccount:
   create: true
 rbac:
   create: true
-  pspEnabled: true
+  pspEnabled: false
 existingSecretDB: "database-pwd-integration-4"
 existingDatarepoDbSecretKey: "datarepopassword"
 existingStairwayDbSecretKey: "stairwaypassword"

--- a/integration/integration-4/datarepo-ui.yaml
+++ b/integration/integration-4/datarepo-ui.yaml
@@ -7,6 +7,6 @@ proxyPass:
 serviceAccount:
   create: true
 rbac:
-  create: true
+  create: false
 nodeSelector:
   cloud.google.com/gke-nodepool: integration-node-2

--- a/integration/integration-4/gcloud-sqlproxy.yaml
+++ b/integration/integration-4/gcloud-sqlproxy.yaml
@@ -11,6 +11,7 @@ cloudsql:
     port: 5432
 rbac:
   create: true
+  pspEnabled: false
 networkPolicy:
   enabled: false
 nodeSelector:

--- a/integration/integration-4/oidc-proxy.yaml
+++ b/integration/integration-4/oidc-proxy.yaml
@@ -23,7 +23,7 @@ ingress:
 serviceAccount:
   create: true
 rbac:
-  create: true
-  pspEnabled: true
+  create: false
+  pspEnabled: false
 nodeSelector:
   cloud.google.com/gke-nodepool: integration-node-2

--- a/integration/integration-5/datarepo-api.yaml
+++ b/integration/integration-5/datarepo-api.yaml
@@ -31,7 +31,7 @@ serviceAccount:
   create: true
 rbac:
   create: true
-  pspEnabled: true
+  pspEnabled: false
 existingSecretDB: "database-pwd-integration-5"
 existingDatarepoDbSecretKey: "datarepopassword"
 existingStairwayDbSecretKey: "stairwaypassword"

--- a/integration/integration-5/datarepo-ui.yaml
+++ b/integration/integration-5/datarepo-ui.yaml
@@ -7,6 +7,6 @@ proxyPass:
 serviceAccount:
   create: true
 rbac:
-  create: true
+  create: false
 nodeSelector:
   cloud.google.com/gke-nodepool: integration-node

--- a/integration/integration-5/gcloud-sqlproxy.yaml
+++ b/integration/integration-5/gcloud-sqlproxy.yaml
@@ -11,6 +11,7 @@ cloudsql:
     port: 5432
 rbac:
   create: true
+  pspEnabled: false
 networkPolicy:
   enabled: false
 nodeSelector:

--- a/integration/integration-5/oidc-proxy.yaml
+++ b/integration/integration-5/oidc-proxy.yaml
@@ -23,7 +23,7 @@ ingress:
 serviceAccount:
   create: true
 rbac:
-  create: true
-  pspEnabled: true
+  create: false
+  pspEnabled: false
 nodeSelector:
   cloud.google.com/gke-nodepool: integration-node

--- a/integration/integration-6/datarepo-api.yaml
+++ b/integration/integration-6/datarepo-api.yaml
@@ -32,7 +32,7 @@ serviceAccount:
   create: true
 rbac:
   create: true
-  pspEnabled: true
+  pspEnabled: false
 existingSecretDB: "database-pwd-integration-6"
 existingDatarepoDbSecretKey: "datarepopassword"
 existingStairwayDbSecretKey: "stairwaypassword"

--- a/integration/integration-6/datarepo-ui.yaml
+++ b/integration/integration-6/datarepo-ui.yaml
@@ -7,6 +7,6 @@ proxyPass:
 serviceAccount:
   create: true
 rbac:
-  create: true
+  create: false
 nodeSelector:
   cloud.google.com/gke-nodepool: integration-node-2

--- a/integration/integration-6/gcloud-sqlproxy.yaml
+++ b/integration/integration-6/gcloud-sqlproxy.yaml
@@ -11,6 +11,7 @@ cloudsql:
     port: 5432
 rbac:
   create: true
+  pspEnabled: false
 networkPolicy:
   enabled: false
 nodeSelector:

--- a/integration/integration-6/oidc-proxy.yaml
+++ b/integration/integration-6/oidc-proxy.yaml
@@ -23,7 +23,7 @@ ingress:
 serviceAccount:
   create: true
 rbac:
-  create: true
-  pspEnabled: true
+  create: false
+  pspEnabled: false
 nodeSelector:
   cloud.google.com/gke-nodepool: integration-node-2

--- a/integration/integration-temp/datarepo-api.yaml
+++ b/integration/integration-temp/datarepo-api.yaml
@@ -31,7 +31,7 @@ serviceAccount:
   create: true
 rbac:
   create: true
-  pspEnabled: true
+  pspEnabled: false
 existingSecretDB: "database-pwd-temp"
 existingDatarepoDbSecretKey: "datarepopassword"
 existingStairwayDbSecretKey: "stairwaypassword"

--- a/integration/integration-temp/datarepo-ui.yaml
+++ b/integration/integration-temp/datarepo-ui.yaml
@@ -9,6 +9,6 @@ proxyPass:
 serviceAccount:
   create: true
 rbac:
-  create: true
+  create: false
 nodeSelector:
   cloud.google.com/gke-nodepool: integration-node

--- a/integration/integration-temp/gcloud-sqlproxy.yaml
+++ b/integration/integration-temp/gcloud-sqlproxy.yaml
@@ -13,6 +13,7 @@ cloudsql:
       port: 5432
 rbac:
   create: true
+  pspEnabled: false
 networkPolicy:
   enabled: false
 nodeSelector:

--- a/integration/integration-temp/oidc-proxy.yaml
+++ b/integration/integration-temp/oidc-proxy.yaml
@@ -22,7 +22,7 @@ ingress:
 serviceAccount:
   create: true
 rbac:
-  create: true
-  pspEnabled: true
+  create: false
+  pspEnabled: false
 nodeSelector:
   cloud.google.com/gke-nodepool: integration-node

--- a/perf/datarepo/datarepo-api.yaml
+++ b/perf/datarepo/datarepo-api.yaml
@@ -36,7 +36,7 @@ serviceAccount:
   create: true
 rbac:
   create: true
-  pspEnabled: true
+  pspEnabled: false
 existingSecretDB: "database-pwd-perf"
 existingDatarepoDbSecretKey: "datarepopassword"
 existingStairwayDbSecretKey: "stairwaypassword"

--- a/perf/datarepo/datarepo-ui.yaml
+++ b/perf/datarepo/datarepo-ui.yaml
@@ -6,4 +6,4 @@ proxyPass:
 serviceAccount:
   create: true
 rbac:
-  create: true
+  create: false

--- a/perf/datarepo/gcloud-sqlproxy.yaml
+++ b/perf/datarepo/gcloud-sqlproxy.yaml
@@ -11,5 +11,6 @@ cloudsql:
     port: 5432
 rbac:
   create: true
+  pspEnabled: false
 networkPolicy:
   enabled: false

--- a/perf/datarepo/oidc-proxy.yaml
+++ b/perf/datarepo/oidc-proxy.yaml
@@ -25,5 +25,5 @@ ingress:
 serviceAccount:
   create: true
 rbac:
-  create: true
-  pspEnabled: true
+  create: false
+  pspEnabled: false

--- a/perf/datarepomonitoring/kube-prometheus-stack.yaml
+++ b/perf/datarepomonitoring/kube-prometheus-stack.yaml
@@ -74,8 +74,8 @@ grafana:
       jvm-dashboard:
         url: https://raw.githubusercontent.com/broadinstitute/datarepo-helm-definitions/master/dashboards/jvm-dashboard.json
   rbac:
-    create: true
-    pspEnabled: true
+    create: false
+    pspEnabled: false
   plugins: ["doitintl-bigquery-datasource"]
   env:
     GF_USERS_AUTO_ASSIGN_ORG_ROLE: "Editor"

--- a/prod/datarepomonitoring/kube-prometheus-stack.yaml
+++ b/prod/datarepomonitoring/kube-prometheus-stack.yaml
@@ -75,8 +75,8 @@ grafana:
       jvm-dashboard:
         url: https://raw.githubusercontent.com/broadinstitute/datarepo-helm-definitions/master/dashboards/jvm-dashboard.json
   rbac:
-    create: true
-    pspEnabled: true
+    create: false
+    pspEnabled: false
   plugins: ["doitintl-bigquery-datasource"]
   env:
     GF_USERS_AUTO_ASSIGN_ORG_ROLE: "Editor"

--- a/scripts/crds/helm-operator/helm-operator.yaml
+++ b/scripts/crds/helm-operator/helm-operator.yaml
@@ -14,4 +14,4 @@ configureRepositories:
     - name: datarepo-helm
       url: https://broadinstitute.github.io/datarepo-helm
 rbac:
-  pspEnabled: true
+  pspEnabled: false

--- a/staging/datarepomonitoring/kube-prometheus-stack.yaml
+++ b/staging/datarepomonitoring/kube-prometheus-stack.yaml
@@ -74,8 +74,8 @@ grafana:
       jvm-dashboard:
         url: https://raw.githubusercontent.com/broadinstitute/datarepo-helm-definitions/master/dashboards/jvm-dashboard.json
   rbac:
-    create: true
-    pspEnabled: true
+    create: false
+    pspEnabled: false
   plugins: ["doitintl-bigquery-datasource"]
   env:
     GF_USERS_AUTO_ASSIGN_ORG_ROLE: "Editor"


### PR DESCRIPTION

This follows the examples set by https://github.com/broadinstitute/terra-helmfile/pull/5222

Cases:
1. Leave rbac.create = true and set rbac.pspEnabled = false
- datarepo-api
- gcloud-sqlproxy

2. Set rbac.create = false (don't set pspEnabled)
- datarepo-ui

3. Set both rbac.create & rbac.pspEnabled to false (the pspEnabled variable isn't actually wired up in these instances - we should get rid of them in the future)
- datarepomonitoring
- oidc-proxy


I also updated the dev deployment. It's no longer used, so seems harmless either way. 

Note the version bump to descheduler. This was needed to deploy to int environment (upgrading this got to the pod security error)